### PR TITLE
Improve message moderation with sentiment filter

### DIFF
--- a/src/pages/MessagePage.js
+++ b/src/pages/MessagePage.js
@@ -6,6 +6,27 @@ import { doc, getDoc, collection, getDocs, addDoc, query, orderBy, Timestamp } f
 import { QRCodeCanvas } from 'qrcode.react';
 import { useGoogleReCaptcha } from 'react-google-recaptcha-v3';
 
+const PROFANE_WORDS = [
+  'amk', 'aq', 'orospu', 'sik', 'sikerim', 'fuck', 'shit', 'bitch', 'pussy',
+  'dick', 'asshole', 'göt', 'piç', 'siktir', 'fucker', 'salak', 'aptal', 'mal'
+];
+
+const NEGATIVE_WORDS = [
+  'kötü', 'rezil', 'berbat', 'nefret', 'iğrenç', 'beğenmedim', 'çirkin',
+  'çok kötü', 'saçma', 'aptalca', 'useless', 'terrible', 'awful',
+  'disgusting', 'hate', 'stupid'
+];
+
+function hasNegativeSentiment(text) {
+  const lower = text.toLowerCase();
+  return NEGATIVE_WORDS.some(word => lower.includes(word));
+}
+
+function containsProfanity(text) {
+  const lower = text.toLowerCase();
+  return PROFANE_WORDS.some(word => lower.includes(word));
+}
+
 const emojis = ['😊', '🎉', '💖', '🥳', '🙏', '🎈', '🌟'];
 
 function MessageForm({
@@ -152,6 +173,14 @@ useEffect(() => {
   const handleSubmit = async (e, token) => {
     e.preventDefault();
     if (!message.trim() || !userId || !token) return;
+    if (
+      containsProfanity(message) ||
+      containsProfanity(name) ||
+      hasNegativeSentiment(message)
+    ) {
+      alert('Lütfen olumlu ve uygun bir dil kullanın.');
+      return;
+    }
     setLoading(true);
     try {
       await addDoc(collection(db, 'users', userId, 'pages', slug, 'messages'), {

--- a/src/pages/UploadPage.js
+++ b/src/pages/UploadPage.js
@@ -107,6 +107,7 @@ const PhotoPage = () => {
       data.append("upload_preset", "soz-uygulamasi");
       data.append("folder", slug);
       data.append("public_id", `${slug}/${Date.now()}-${fileName}`);
+      data.append("moderation", "webpurify");
 
       try {
         const res = await fetch(`https://api.cloudinary.com/v1_1/${cloudinaryName}/auto/upload`, {
@@ -115,6 +116,10 @@ const PhotoPage = () => {
         });
         const result = await res.json();
 
+        if (result.moderation && result.moderation[0] && result.moderation[0].status === 'rejected') {
+          alert('Yüklenen dosya uygunsuz içerik olarak işaretlendi ve reddedildi.');
+          continue;
+        }
         if (result.secure_url) {
           await addDoc(collection(db, 'photos', slug, 'entries'), {
             url: result.secure_url,


### PR DESCRIPTION
## Summary
- add a basic list of negative words and a sentiment check for messages
- block negative or profane messages before saving

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879f386ae8832d861e4009230341c7