### PR TITLE
Fix toast notifications

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import 'react-toastify/dist/ReactToastify.css';
 import App from './App';
 import { AuthProvider } from './context/AuthContext';
 import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3';
+import { ToastContainer } from 'react-toastify';
 
 const SITE_KEY = process.env.REACT_APP_GOOGLE_SITE_KEY;
 const root = ReactDOM.createRoot(document.getElementById('root'));
@@ -11,8 +13,9 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <AuthProvider>
-    <GoogleReCaptchaProvider reCaptchaKey={SITE_KEY}>
-      <App />
+      <GoogleReCaptchaProvider reCaptchaKey={SITE_KEY}>
+        <App />
+        <ToastContainer />
       </GoogleReCaptchaProvider>
     </AuthProvider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- enable toast notifications by adding ToastContainer to the app

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887abbc3bb0832dad9d06f9ba3e47c4