### PR TITLE
Fix sign-in fallback on new Firebase error codes

### DIFF
--- a/src/pages/AuthPage.js
+++ b/src/pages/AuthPage.js
@@ -3,6 +3,8 @@ import { auth } from '../databases/firebase';
 import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from 'firebase/auth';
 import { useNavigate } from 'react-router-dom';
 import { GoogleReCaptchaProvider, useGoogleReCaptcha } from 'react-google-recaptcha-v3';
+import { getAuthErrorMessage } from '../utils/authErrors';
+import { isPasswordValid } from '../utils/validation';
 
 const SITE_KEY = process.env.REACT_APP_GOOGLE_SITE_KEY; // reCAPTCHA v3 anahtarınız
 
@@ -17,6 +19,11 @@ const AuthForm = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
+
+    if (!isPasswordValid(password)) {
+      setError('Şifre en az bir büyük harf, bir küçük harf ve bir noktalama işareti içermelidir.');
+      return;
+    }
 
     if (!executeRecaptcha) {
       setError('Recaptcha yüklenemedi');
@@ -36,7 +43,7 @@ const AuthForm = () => {
       }
       navigate('/dashboard');
     } catch (err) {
-      setError(err.message);
+      setError(getAuthErrorMessage(err.code));
     }
   };
 

--- a/src/utils/authErrors.js
+++ b/src/utils/authErrors.js
@@ -1,0 +1,21 @@
+export const getAuthErrorMessage = (code) => {
+  switch (code) {
+    case 'auth/invalid-email':
+      return 'Geçersiz e-posta adresi';
+    case 'auth/missing-password':
+      return 'Parola alanı boş bırakılamaz';
+    case 'auth/weak-password':
+      return 'Parola çok zayıf';
+    case 'auth/email-already-in-use':
+      return 'Bu e-posta zaten kullanılıyor';
+    case 'auth/wrong-password':
+      return 'Yanlış parola';
+    case 'auth/user-not-found':
+      return 'Kullanıcı bulunamadı';
+    case 'auth/invalid-login-credentials':
+    case 'auth/invalid-credential':
+      return 'E-posta veya parola hatalı';
+    default:
+      return 'Bir hata oluştu. Lütfen tekrar deneyin';
+  }
+};

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,6 @@
+export const isPasswordValid = (password) => {
+  const hasUpper = /[A-Z]/.test(password);
+  const hasLower = /[a-z]/.test(password);
+  const hasPunct = /[^\w\s]/.test(password);
+  return hasUpper && hasLower && hasPunct;
+};


### PR DESCRIPTION
## Summary
- handle `auth/invalid-login-credentials` and `auth/invalid-credential` when signing in
- validate password complexity
- show translated error messages for common auth failures

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm install --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6887c692aaa0832db5c3c33c807ea80e