### PR TITLE
Add draggable preview text and dashboard link

### DIFF
--- a/src/components/DraggableText.js
+++ b/src/components/DraggableText.js
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+
+const DraggableText = ({ children, style, className, ...rest }) => {
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+
+  const startDrag = (clientX, clientY) => {
+    const startX = clientX - pos.x;
+    const startY = clientY - pos.y;
+
+    const onMove = (moveEvent) => {
+      const x = moveEvent.clientX !== undefined ? moveEvent.clientX : moveEvent.touches[0].clientX;
+      const y = moveEvent.clientY !== undefined ? moveEvent.clientY : moveEvent.touches[0].clientY;
+      setPos({ x: x - startX, y: y - startY });
+    };
+
+    const endMove = () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', endMove);
+      document.removeEventListener('touchmove', onMove);
+      document.removeEventListener('touchend', endMove);
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', endMove);
+    document.addEventListener('touchmove', onMove);
+    document.addEventListener('touchend', endMove);
+  };
+
+  const handleMouseDown = (e) => {
+    e.preventDefault();
+    startDrag(e.clientX, e.clientY);
+  };
+
+  const handleTouchStart = (e) => {
+    startDrag(e.touches[0].clientX, e.touches[0].clientY);
+  };
+
+  return (
+    <div
+      onMouseDown={handleMouseDown}
+      onTouchStart={handleTouchStart}
+      style={{ position: 'relative', left: pos.x, top: pos.y, cursor: 'move', ...style }}
+      className={className}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default DraggableText;

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import DraggableText from '../components/DraggableText';
 import { useAuth } from '../context/AuthContext';
 import { signOut } from 'firebase/auth';
 import { auth, db } from '../databases/firebase';
@@ -439,24 +440,24 @@ const deleteCollection = async (collectionRef) => {
                 style={bgPreview ? { backgroundImage: `url(${bgPreview})` } : backgroundImage ? { backgroundImage: `url(${backgroundImage})` } : {}}
               >
                 <div className="flex-1 p-8 flex flex-col items-center justify-center text-center">
-                  <p
+                  <DraggableText
                     className={`text-sm mb-8 italic ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
                     style={{ color: subtitleColor }}
                   >
                     {subtitle || 'Sözümüze Hoşgeldiniz...'}
-                  </p>
-                  <h1
+                  </DraggableText>
+                  <DraggableText
                     className={`text-3xl font-bold mb-8 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
                     style={{ color: titleColor }}
                   >
                     {title || 'Burcu & Fatih'}
-                  </h1>
-                  <p
+                  </DraggableText>
+                  <DraggableText
                     className={`text-sm mb-8 ${altFont ? `font-${altFont}` : 'font-sans'}`}
                     style={{ color: altColor }}
                   >
                     {altText || 'Bizimkisi bir aşk hikayesi..'}
-                  </p>
+                  </DraggableText>
                 </div>
                 <div className="p-4 text-center border-t">
                   <p className="text-xs text-gray-500">

--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -1,5 +1,6 @@
 // filepath: [HeroPage.js](http://_vscodecontentref_/0)
 import React, { useState, useEffect } from 'react';
+import DraggableText from '../components/DraggableText';
 import { useNavigate } from 'react-router-dom';
 import { auth, db } from '../databases/firebase';
 import { 
@@ -349,24 +350,24 @@ const HeroPage = () => {
                 className="flex-1 p-8 flex flex-col items-center justify-center text-center bg-cover bg-center"
                 style={bgPreview ? { backgroundImage: `url(${bgPreview})` } : backgroundImage ? { backgroundImage: `url(${backgroundImage})` } : {}}
               >
-                <p
+                <DraggableText
                   className={`text-sm mb-8 italic ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
                   style={{ color: subtitleColor }}
                 >
                   {subtitle || 'Sözümüze Hoşgeldiniz...'}
-                </p>
-                <h1
+                </DraggableText>
+                <DraggableText
                   className={`text-3xl font-bold mb-8 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
                   style={{ color: titleColor }}
                 >
                   {title || 'Burcu & Fatih'}
-                </h1>
-                <p
+                </DraggableText>
+                <DraggableText
                   className={`text-sm mb-8 ${altFont ? `font-${altFont}` : 'font-sans'}`}
                   style={{ color: altColor }}
                 >
                   {altText || 'Bizimkisi bir aşk hikayesi..'}
-                </p>
+                </DraggableText>
               </div>
               <div className="p-4 text-center border-t">
                 <p className="text-xs text-gray-500">
@@ -580,6 +581,12 @@ const HeroPage = () => {
                 className="w-full bg-pink-500 hover:bg-pink-600 text-white font-medium py-3 px-6 rounded-lg disabled:opacity-50"
               >
                 {loading ? 'Oluşturuluyor...' : 'Sayfayı Oluştur'}
+              </button>
+              <button
+                onClick={handleGoToDashboard}
+                className="w-full bg-gray-500 hover:bg-gray-600 text-white font-medium py-3 px-6 rounded-lg mt-2"
+              >
+                Dashboard'a Geç
               </button>
             </div>
           )}


### PR DESCRIPTION
## Summary
- implement `DraggableText` component to make preview labels draggable
- use `DraggableText` in HeroPage and DashboardPage previews
- show `Dashboard'a Geç` button below `Sayfayı Oluştur` after login

## Testing
- `npm test -- -w=0`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887f057f838832da522ebe4005ba810