### PR TITLE
Add web preview mode

### DIFF
--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -40,6 +40,7 @@ const DashboardPage = () => {
   const [bgPreview, setBgPreview] = useState('');
   const [bgUploading, setBgUploading] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
+  const [previewMode, setPreviewMode] = useState('mobile');
   const [slugExists, setSlugExists] = useState(false);
   const [slugMessage, setSlugMessage] = useState('');
   const [qrModalOpen, setQrModalOpen] = useState(false);
@@ -227,7 +228,7 @@ const deleteCollection = async (collectionRef) => {
 
   return (
     <div className="min-h-screen bg-[#f4ecd8] px-4 py-8">
-      <div className="max-w-2xl mx-auto bg-white shadow-md rounded-xl p-6 space-y-6">
+      <div className="max-w-5xl mx-auto bg-white shadow-md rounded-xl p-6 space-y-6 lg:flex lg:space-y-0 lg:space-x-6">
         <h1 className="text-3xl font-semibold text-center">🎛️ Kontrol Paneli</h1>
         <p className="text-sm text-center text-gray-500">Hoş geldiniz: {user.email}</p>
         <div className="text-center">
@@ -237,7 +238,17 @@ const deleteCollection = async (collectionRef) => {
           >
             {showPreview ? 'Önizlemeyi Kapat' : 'Önizlemeyi Göster'}
           </button>
+          {showPreview && (
+            <button
+              onClick={() => setPreviewMode(previewMode === 'mobile' ? 'web' : 'mobile')}
+              className="ml-2 mt-2 bg-purple-500 hover:bg-purple-600 text-white text-sm px-4 py-2 rounded shadow"
+            >
+              {previewMode === 'mobile' ? 'Web Önizleme' : 'Mobil Önizleme'}
+            </button>
+          )}
         </div>
+
+        <div className="flex-1 space-y-6">
 
         <div>
           <label className="block text-gray-700 mb-1">🔗 Sayfa Linki</label>
@@ -433,7 +444,8 @@ const deleteCollection = async (collectionRef) => {
         </div>
 
         {showPreview && (
-          <div className="flex justify-center mt-4">
+          <div className="lg:w-1/2 flex justify-center mt-4">
+            {previewMode === 'mobile' ? (
             <div className="w-[300px] h-[600px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white">
               <div
                 className="h-full flex flex-col bg-cover bg-center"
@@ -466,6 +478,13 @@ const deleteCollection = async (collectionRef) => {
                 </div>
               </div>
             </div>
+            ) : (
+              <iframe
+                src={slug ? `/${slug}` : '/'}
+                title="web preview"
+                className="w-full h-[600px] border rounded-xl"
+              />
+            )}
           </div>
         )}
         <button
@@ -754,6 +773,7 @@ const deleteCollection = async (collectionRef) => {
           >
             Çıkış Yap
           </button>
+        </div>
         </div>
       </div>
     </div>

--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -49,6 +49,7 @@ const HeroPage = () => {
   // QR Kod ve paylaşım state'leri
   const [showQRModal, setShowQRModal] = useState(false);
   const [createdPageUrl, setCreatedPageUrl] = useState('');
+  const [previewMode, setPreviewMode] = useState('mobile');
 
   const handleBgChange = (e) => {
     const file = e.target.files[0];
@@ -343,7 +344,14 @@ const HeroPage = () => {
       <div className="flex flex-col lg:flex-row min-h-[80vh]">
 
         {/* Önizleme - Mobilde Üstte, Masaüstünde Sağda */}
-        <div className="w-full lg:w-1/2 bg-gradient-to-br from-pink-50 to-purple-50 p-6 flex items-center justify-center">
+        <div className="w-full lg:w-1/2 bg-gradient-to-br from-pink-50 to-purple-50 p-6 flex flex-col items-center">
+          <button
+            onClick={() => setPreviewMode(previewMode === 'mobile' ? 'web' : 'mobile')}
+            className="mb-4 bg-purple-500 hover:bg-purple-600 text-white text-sm px-4 py-2 rounded shadow"
+          >
+            {previewMode === 'mobile' ? 'Web Önizleme' : 'Mobil Önizleme'}
+          </button>
+          {previewMode === 'mobile' ? (
           <div className="w-full max-w-[320px] h-[600px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white">
             <div className="h-full flex flex-col">
               <div
@@ -376,6 +384,13 @@ const HeroPage = () => {
               </div>
             </div>
           </div>
+          ) : (
+            <iframe
+              src={slug ? `/${slug}` : '/'}
+              title="web preview"
+              className="w-full h-[600px] border rounded-xl"
+            />
+          )}
         </div>
 
         {/* Form - Mobilde Altta, Masaüstünde Solda */}


### PR DESCRIPTION
## Summary
- allow switching between mobile and web preview on HeroPage and Dashboard
- show preview on the right side of Dashboard

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6887f2ec15c4832d934749cd5555d00f