### PR TITLE
Add dashboard button on HeroPage

### DIFF
--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -481,6 +481,12 @@ const HeroPage = () => {
               >
                 {loading ? 'Oluşturuluyor...' : 'Sayfayı Oluştur'}
               </button>
+              <button
+                onClick={() => navigate('/dashboard')}
+                className="w-full bg-gray-500 hover:bg-gray-600 text-white font-medium py-3 px-6 rounded-lg"
+              >
+                Dashboard'a Geç
+              </button>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- add navigation button to dashboard under page creation form on HeroPage

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68885dcde6bc832d86e22474c44605ed