### PR TITLE
Fix mobile footer layout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -46,24 +46,32 @@ function App() {
         </Routes>
       </Router>
 
-<div
-  className="fixed bottom-4 left-4 p-2 rounded-full shadow-lg cursor-pointer hover:scale-105 transition bg-white"
-  title="Bize kahve ısmarla ☕"
-  onClick={() => window.open('https://coff.ee/erenevimmd', '_blank')}
->
-  <div className="relative w-16 h-16">
-    <QRCodeCanvas
-      value="https://coff.ee/erenevimmd"
-      size={64}
-      bgColor="#ffffff"
-      fgColor="#ef4444"
-      level="H"
-      includeMargin={false}
-    />
-    <div className="absolute inset-0 flex items-center justify-center">
-      <span className="text-[8px] font-bold text-red-600 bg-white bg-opacity-80 px-1 rounded">
-        Destek Ol
-      </span>
+<div className="fixed bottom-4 left-4 z-40 flex flex-col items-start gap-2">
+  <button
+    className="md:hidden bg-red-500 hover:bg-red-600 text-white text-sm px-3 py-2 rounded shadow"
+    onClick={() => window.open('https://coff.ee/erenevimmd', '_blank')}
+  >
+    ☕ Destek Ol
+  </button>
+  <div
+    className="hidden md:block p-2 rounded-full shadow-lg cursor-pointer hover:scale-105 transition bg-white"
+    title="Bize kahve ısmarla ☕"
+    onClick={() => window.open('https://coff.ee/erenevimmd', '_blank')}
+  >
+    <div className="relative w-16 h-16">
+      <QRCodeCanvas
+        value="https://coff.ee/erenevimmd"
+        size={64}
+        bgColor="#ffffff"
+        fgColor="#ef4444"
+        level="H"
+        includeMargin={false}
+      />
+      <div className="absolute inset-0 flex items-center justify-center">
+        <span className="text-[8px] font-bold text-red-600 bg-white bg-opacity-80 px-1 rounded">
+          Destek Ol
+        </span>
+      </div>
     </div>
   </div>
 </div>

--- a/src/index.css
+++ b/src/index.css
@@ -5,3 +5,16 @@
 html {
   scroll-behavior: smooth;
 }
+
+/* reCAPTCHA rozeti boyutunu küçült */
+.grecaptcha-badge {
+  transform: scale(0.8);
+  transform-origin: bottom right;
+}
+
+@media (max-width: 640px) {
+  .grecaptcha-badge {
+    transform: scale(0.55);
+    transform-origin: bottom right;
+  }
+}

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -192,7 +192,7 @@ const deleteCollection = async (collectionRef) => {
   if (loading) return <div className="text-center p-10">Yükleniyor...</div>;
 
   return (
-    <div className="min-h-screen bg-[#f4ecd8] px-4 py-8">
+    <div className="min-h-screen bg-[#f4ecd8] px-4 py-8 pb-32">
       <div className="max-w-2xl mx-auto bg-white shadow-md rounded-xl p-6 space-y-6">
         <h1 className="text-3xl font-semibold text-center">🎛️ Kontrol Paneli</h1>
         <p className="text-sm text-center text-gray-500">Hoş geldiniz: {user.email}</p>


### PR DESCRIPTION
## Summary
- add padding to the dashboard page so the footer buttons stay above floating widgets
- swap QR donate widget to a responsive button on mobile
- shrink the reCAPTCHA badge

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888a5bcc81c832d871d2c6d8ed3fa32