### PR TITLE
Add desktop preview to hero creation modal

### DIFF
--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -44,6 +44,71 @@ const HeroPage = () => {
   const [showQRModal, setShowQRModal] = useState(false);
   const [createdPageUrl, setCreatedPageUrl] = useState('');
 
+  const PhonePreview = () => (
+    <div className="block lg:hidden w-full max-w-[320px] h-[600px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white">
+      <div className="h-full flex flex-col">
+        <div className="flex-1 p-8 flex flex-col items-center justify-center text-center">
+          <p
+            className={`text-sm mb-8 italic ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
+            style={{ color: subtitleColor }}
+          >
+            {subtitle || 'Sözümüze Hoşgeldiniz...'}
+          </p>
+          <h1
+            className={`text-3xl font-bold mb-8 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
+            style={{ color: titleColor }}
+          >
+            {title || 'Burcu & Fatih'}
+          </h1>
+          <p
+            className={`text-sm mb-8 ${altFont ? `font-${altFont}` : 'font-sans'}`}
+            style={{ color: altColor }}
+          >
+            {altText || 'Bizimkisi bir aşk hikayesi..'}
+          </p>
+        </div>
+        <div className="p-4 text-center border-t">
+          <p className="text-xs text-gray-500">
+            {slug ? `${window.location.origin}/${slug}` : 'sayfa-url.com/slug'}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+
+  const WebPreview = () => (
+    <div className="hidden lg:flex w-full max-w-xl h-[600px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white">
+      <div className="flex-1 flex flex-col items-center justify-center text-center px-10 relative">
+        <p
+          className={`italic text-xl mb-4 ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
+          style={{ color: subtitleColor }}
+        >
+          {subtitle || 'Sözümüze Hoşgeldiniz...'}
+        </p>
+        <h1
+          className={`text-5xl font-bold mb-3 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
+          style={{ color: titleColor }}
+        >
+          {title || 'Burcu & Fatih'}
+        </h1>
+        <p
+          className={`text-base mt-4 ${altFont ? `font-${altFont}` : 'font-sans'}`}
+          style={{ color: altColor }}
+        >
+          {altText || 'Bizimkisi bir aşk hikayesi..'}
+        </p>
+        <svg className="w-8 h-8 text-gray-500 absolute bottom-4 animate-bounce" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </div>
+      <div className="p-4 text-center border-t">
+        <p className="text-sm text-gray-500">
+          {slug ? `${window.location.origin}/${slug}` : 'sayfa-url.com/slug'}
+        </p>
+      </div>
+    </div>
+  );
+
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
       setUser(currentUser);
@@ -280,35 +345,8 @@ const HeroPage = () => {
 
         {/* Önizleme - Mobilde Üstte, Masaüstünde Sağda */}
         <div className="w-full lg:w-1/2 bg-gradient-to-br from-pink-50 to-purple-50 p-6 flex items-center justify-center">
-          <div className="w-full max-w-[320px] h-[600px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white">
-            <div className="h-full flex flex-col">
-              <div className="flex-1 p-8 flex flex-col items-center justify-center text-center">
-                <p
-                  className={`text-sm mb-8 italic ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
-                  style={{ color: subtitleColor }}
-                >
-                  {subtitle || 'Sözümüze Hoşgeldiniz...'}
-                </p>
-                <h1
-                  className={`text-3xl font-bold mb-8 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
-                  style={{ color: titleColor }}
-                >
-                  {title || 'Burcu & Fatih'}
-                </h1>
-                <p
-                  className={`text-sm mb-8 ${altFont ? `font-${altFont}` : 'font-sans'}`}
-                  style={{ color: altColor }}
-                >
-                  {altText || 'Bizimkisi bir aşk hikayesi..'}
-                </p>
-              </div>
-              <div className="p-4 text-center border-t">
-                <p className="text-xs text-gray-500">
-                  {slug ? `${window.location.origin}/${slug}` : 'sayfa-url.com/slug'}
-                </p>
-              </div>
-            </div>
-          </div>
+          <PhonePreview />
+          <WebPreview />
         </div>
 
         {/* Form - Mobilde Altta, Masaüstünde Solda */}


### PR DESCRIPTION
## Summary
- show additional desktop preview alongside phone preview for slug creation
- only display desktop preview on large screens

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68891c1e35b4832dac640e7a9d670397