### PR TITLE
Fix modal preview layout

### DIFF
--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -77,9 +77,12 @@ const HeroPage = () => {
   );
 
   const WebPreview = () => (
-    <div className="hidden lg:flex flex-col w-full max-w-xl h-[600px] bg-white rounded-3xl shadow-xl overflow-hidden border border-gray-200">
-      <div className="bg-gray-100 px-4 py-2 border-b">
-        <p className="text-xs text-gray-500 text-center">
+    <div className="hidden lg:flex flex-col w-full max-w-xl h-[600px] bg-white rounded-lg shadow-xl overflow-hidden border border-gray-200">
+      <div className="bg-gray-100 flex items-center px-4 py-2 space-x-1 border-b">
+        <span className="w-3 h-3 bg-red-500 rounded-full" />
+        <span className="w-3 h-3 bg-yellow-500 rounded-full" />
+        <span className="w-3 h-3 bg-green-500 rounded-full" />
+        <p className="flex-1 text-xs text-gray-500 text-center">
           {slug ? `${window.location.origin}/${slug}` : 'sayfa-url.com/slug'}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- update the WebPreview design so mobile and desktop previews are distinct

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6889242cd4a8832dad5d545095fe10f7