### PR TITLE
Fix web preview modal on mobile

### DIFF
--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -78,7 +78,7 @@ const HeroPage = () => {
   );
 
   const WebPreview = () => (
-    <div className="hidden lg:flex flex-col w-full max-w-xl h-[600px] bg-white rounded-lg shadow-xl overflow-hidden border border-gray-200">
+    <div className="flex flex-col w-full max-w-xl h-[600px] bg-white rounded-lg shadow-xl overflow-hidden border border-gray-200">
       <div className="bg-gray-100 flex items-center px-4 py-2 space-x-1 border-b">
         <span className="w-3 h-3 bg-red-500 rounded-full" />
         <span className="w-3 h-3 bg-yellow-500 rounded-full" />


### PR DESCRIPTION
## Summary
- show WebPreview on small screens

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688927d1a79c832d822ba5b5387dc279