### PR TITLE
Add preview components and integrate into pages

### DIFF
--- a/src/components/Preview/PhonePreview.js
+++ b/src/components/Preview/PhonePreview.js
@@ -1,0 +1,46 @@
+import React from 'react';
+
+const PhonePreview = ({
+  slug,
+  title,
+  subtitle,
+  altText,
+  titleFont,
+  titleColor,
+  subtitleFont,
+  subtitleColor,
+  altFont,
+  altColor
+}) => (
+  <div className="block w-full max-w-[320px] h-[600px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white">
+    <div className="h-full flex flex-col">
+      <div className="flex-1 p-8 flex flex-col items-center justify-center text-center">
+        <p
+          className={`text-sm mb-8 italic ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
+          style={{ color: subtitleColor }}
+        >
+          {subtitle || 'Sözümüze Hoşgeldiniz...'}
+        </p>
+        <h1
+          className={`text-3xl font-bold mb-8 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
+          style={{ color: titleColor }}
+        >
+          {title || 'Burcu & Fatih'}
+        </h1>
+        <p
+          className={`text-sm mb-8 ${altFont ? `font-${altFont}` : 'font-sans'}`}
+          style={{ color: altColor }}
+        >
+          {altText || 'Bizimkisi bir aşk hikayesi..'}
+        </p>
+      </div>
+      <div className="p-4 text-center border-t">
+        <p className="text-xs text-gray-500">
+          {slug ? `${window.location.origin}/${slug}` : 'sayfa-url.com/slug'}
+        </p>
+      </div>
+    </div>
+  </div>
+);
+
+export default PhonePreview;

--- a/src/components/Preview/WebPreview.js
+++ b/src/components/Preview/WebPreview.js
@@ -1,0 +1,56 @@
+import React from 'react';
+
+const WebPreview = ({
+  slug,
+  title,
+  subtitle,
+  altText,
+  titleFont,
+  titleColor,
+  subtitleFont,
+  subtitleColor,
+  altFont,
+  altColor
+}) => (
+  <div className="flex flex-col w-full max-w-xl h-[600px] bg-white rounded-lg shadow-xl overflow-hidden border border-gray-200">
+    <div className="bg-gray-100 flex items-center px-4 py-2 space-x-1 border-b">
+      <span className="w-3 h-3 bg-red-500 rounded-full" />
+      <span className="w-3 h-3 bg-yellow-500 rounded-full" />
+      <span className="w-3 h-3 bg-green-500 rounded-full" />
+      <p className="flex-1 text-xs text-gray-500 text-center">
+        {slug ? `${window.location.origin}/${slug}` : 'sayfa-url.com/slug'}
+      </p>
+    </div>
+    <div className="flex-1 flex flex-col items-center justify-center text-center px-10 relative">
+      <p
+        className={`italic text-xl mb-4 ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
+        style={{ color: subtitleColor }}
+      >
+        {subtitle || 'Sözümüze Hoşgeldiniz...'}
+      </p>
+      <h1
+        className={`text-5xl font-bold mb-3 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
+        style={{ color: titleColor }}
+      >
+        {title || 'Burcu & Fatih'}
+      </h1>
+      <p
+        className={`text-base mt-4 ${altFont ? `font-${altFont}` : 'font-sans'}`}
+        style={{ color: altColor }}
+      >
+        {altText || 'Bizimkisi bir aşk hikayesi..'}
+      </p>
+      <svg
+        className="w-8 h-8 text-gray-500 absolute bottom-4 animate-bounce"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+      </svg>
+    </div>
+  </div>
+);
+
+export default WebPreview;

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -5,6 +5,8 @@ import { auth, db } from '../databases/firebase';
 import { useNavigate } from 'react-router-dom';
 import QRCode from "react-qr-code";
 import { toPng } from 'html-to-image';
+import PhonePreview from '../components/Preview/PhonePreview';
+import WebPreview from '../components/Preview/WebPreview';
 import {
   collection,
   getDocs,
@@ -37,6 +39,7 @@ const DashboardPage = () => {
   const [slugMessage, setSlugMessage] = useState('');
   const [qrModalOpen, setQrModalOpen] = useState(false);
   const [qrValue, setQrValue] = useState('');
+  const [previewType, setPreviewType] = useState('phone');
 
 const qrRef = useRef(null);
 const invalidSlugRegex = /[^a-zA-Z-]/;
@@ -196,6 +199,50 @@ const deleteCollection = async (collectionRef) => {
       <div className="max-w-2xl mx-auto bg-white shadow-md rounded-xl p-6 space-y-6">
         <h1 className="text-3xl font-semibold text-center">🎛️ Kontrol Paneli</h1>
         <p className="text-sm text-center text-gray-500">Hoş geldiniz: {user.email}</p>
+
+        <div className="flex flex-col items-center">
+          <div className="flex space-x-2 mb-4">
+            <button
+              onClick={() => setPreviewType('phone')}
+              className={`px-3 py-1 rounded-lg border ${previewType === 'phone' ? 'bg-pink-500 text-white border-pink-500' : 'bg-white text-gray-700'}`}
+            >
+              Mobil
+            </button>
+            <button
+              onClick={() => setPreviewType('web')}
+              className={`px-3 py-1 rounded-lg border ${previewType === 'web' ? 'bg-pink-500 text-white border-pink-500' : 'bg-white text-gray-700'}`}
+            >
+              Web
+            </button>
+          </div>
+          {previewType === 'phone' ? (
+            <PhonePreview
+              slug={slug}
+              title={title}
+              subtitle={subtitle}
+              altText={altText}
+              titleFont={titleFont}
+              titleColor={titleColor}
+              subtitleFont={subtitleFont}
+              subtitleColor={subtitleColor}
+              altFont={altFont}
+              altColor={altColor}
+            />
+          ) : (
+            <WebPreview
+              slug={slug}
+              title={title}
+              subtitle={subtitle}
+              altText={altText}
+              titleFont={titleFont}
+              titleColor={titleColor}
+              subtitleFont={subtitleFont}
+              subtitleColor={subtitleColor}
+              altFont={altFont}
+              altColor={altColor}
+            />
+          )}
+        </div>
 
         <div>
           <label className="block text-gray-700 mb-1">🔗 Sayfa Linki</label>

--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -11,6 +11,8 @@ import { doc, setDoc, getDoc } from 'firebase/firestore';
 import { toast } from 'react-toastify';
 import QRCode from 'react-qr-code';
 import FontSelector from '../components/FontSelector';
+import PhonePreview from '../components/Preview/PhonePreview';
+import WebPreview from '../components/Preview/WebPreview';
 import { getAuthErrorMessage } from '../utils/authErrors';
 import { isPasswordValid } from '../utils/validation';
 
@@ -45,79 +47,6 @@ const HeroPage = () => {
   const [createdPageUrl, setCreatedPageUrl] = useState('');
   const [previewType, setPreviewType] = useState('phone');
 
-  const PhonePreview = () => (
-    <div className="block w-full max-w-[320px] h-[600px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white">
-      <div className="h-full flex flex-col">
-        <div className="flex-1 p-8 flex flex-col items-center justify-center text-center">
-          <p
-            className={`text-sm mb-8 italic ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
-            style={{ color: subtitleColor }}
-          >
-            {subtitle || 'Sözümüze Hoşgeldiniz...'}
-          </p>
-          <h1
-            className={`text-3xl font-bold mb-8 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
-            style={{ color: titleColor }}
-          >
-            {title || 'Burcu & Fatih'}
-          </h1>
-          <p
-            className={`text-sm mb-8 ${altFont ? `font-${altFont}` : 'font-sans'}`}
-            style={{ color: altColor }}
-          >
-            {altText || 'Bizimkisi bir aşk hikayesi..'}
-          </p>
-        </div>
-        <div className="p-4 text-center border-t">
-          <p className="text-xs text-gray-500">
-            {slug ? `${window.location.origin}/${slug}` : 'sayfa-url.com/slug'}
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-
-  const WebPreview = () => (
-    <div className="flex flex-col w-full max-w-xl h-[600px] bg-white rounded-lg shadow-xl overflow-hidden border border-gray-200">
-      <div className="bg-gray-100 flex items-center px-4 py-2 space-x-1 border-b">
-        <span className="w-3 h-3 bg-red-500 rounded-full" />
-        <span className="w-3 h-3 bg-yellow-500 rounded-full" />
-        <span className="w-3 h-3 bg-green-500 rounded-full" />
-        <p className="flex-1 text-xs text-gray-500 text-center">
-          {slug ? `${window.location.origin}/${slug}` : 'sayfa-url.com/slug'}
-        </p>
-      </div>
-      <div className="flex-1 flex flex-col items-center justify-center text-center px-10 relative">
-        <p
-          className={`italic text-xl mb-4 ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
-          style={{ color: subtitleColor }}
-        >
-          {subtitle || 'Sözümüze Hoşgeldiniz...'}
-        </p>
-        <h1
-          className={`text-5xl font-bold mb-3 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
-          style={{ color: titleColor }}
-        >
-          {title || 'Burcu & Fatih'}
-        </h1>
-        <p
-          className={`text-base mt-4 ${altFont ? `font-${altFont}` : 'font-sans'}`}
-          style={{ color: altColor }}
-        >
-          {altText || 'Bizimkisi bir aşk hikayesi..'}
-        </p>
-        <svg
-          className="w-8 h-8 text-gray-500 absolute bottom-4 animate-bounce"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          viewBox="0 0 24 24"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-        </svg>
-      </div>
-    </div>
-  );
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
@@ -369,7 +298,33 @@ const HeroPage = () => {
               Web
             </button>
           </div>
-          {previewType === 'phone' ? <PhonePreview /> : <WebPreview />}
+          {previewType === 'phone' ? (
+            <PhonePreview
+              slug={slug}
+              title={title}
+              subtitle={subtitle}
+              altText={altText}
+              titleFont={titleFont}
+              titleColor={titleColor}
+              subtitleFont={subtitleFont}
+              subtitleColor={subtitleColor}
+              altFont={altFont}
+              altColor={altColor}
+            />
+          ) : (
+            <WebPreview
+              slug={slug}
+              title={title}
+              subtitle={subtitle}
+              altText={altText}
+              titleFont={titleFont}
+              titleColor={titleColor}
+              subtitleFont={subtitleFont}
+              subtitleColor={subtitleColor}
+              altFont={altFont}
+              altColor={altColor}
+            />
+          )}
         </div>
 
         {/* Form - Mobilde Altta, Masaüstünde Solda */}


### PR DESCRIPTION
## Summary
- add reusable `PhonePreview` and `WebPreview` components
- integrate previews into `HeroPage` modal
- integrate previews into `DashboardPage`

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688929e433b8832d9eb4969a7025aa4c