### PR TITLE
Enable draggable preview text editing

### DIFF
--- a/src/components/DraggableEditableText.js
+++ b/src/components/DraggableEditableText.js
@@ -1,0 +1,62 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+const DraggableEditableText = ({
+  text,
+  onChange,
+  className,
+  style,
+  pos = { x: 0, y: 0 },
+  onPosChange,
+}) => {
+  const [editing, setEditing] = useState(false);
+  const [position, setPosition] = useState(pos);
+  const start = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    setPosition(pos);
+  }, [pos]);
+
+  const handleMouseDown = (e) => {
+    if (editing) return;
+    start.current = { x: e.clientX - position.x, y: e.clientY - position.y };
+    const handleMouseMove = (e2) => {
+      const newPos = {
+        x: e2.clientX - start.current.x,
+        y: e2.clientY - start.current.y,
+      };
+      setPosition(newPos);
+      onPosChange?.(newPos);
+    };
+    const handleMouseUp = () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  };
+
+  return (
+    <span
+      onMouseDown={handleMouseDown}
+      onDoubleClick={() => setEditing(true)}
+      style={{ position: 'absolute', left: position.x, top: position.y, cursor: editing ? 'text' : 'move', ...style }}
+      className={className}
+    >
+      {editing ? (
+        <input
+          value={text}
+          autoFocus
+          onChange={(e) => onChange(e.target.value)}
+          onBlur={() => setEditing(false)}
+          className="border border-gray-300 rounded px-1"
+        />
+      ) : (
+        text
+      )}
+    </span>
+  );
+};
+
+export default DraggableEditableText;
+
+

--- a/src/components/Preview/PhonePreview.js
+++ b/src/components/Preview/PhonePreview.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import DraggableEditableText from '../DraggableEditableText';
 
 const PhonePreview = ({
   slug,
@@ -10,29 +11,44 @@ const PhonePreview = ({
   subtitleFont,
   subtitleColor,
   altFont,
-  altColor
+  altColor,
+  onTitleChange,
+  onSubtitleChange,
+  onAltTextChange,
+  titlePos,
+  subtitlePos,
+  altTextPos,
+  onTitlePosChange,
+  onSubtitlePosChange,
+  onAltTextPosChange,
 }) => (
-  <div className="block w-full max-w-[320px] h-[600px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white">
+  <div className="block w-full max-w-[320px] h-[600px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white relative">
     <div className="h-full flex flex-col">
-      <div className="flex-1 p-8 flex flex-col items-center justify-center text-center">
-        <p
+      <div className="flex-1 p-8 flex flex-col items-center justify-center text-center relative">
+        <DraggableEditableText
+          text={subtitle || 'Sözümüze Hoşgeldiniz...'}
+          onChange={onSubtitleChange}
           className={`text-sm mb-8 italic ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
           style={{ color: subtitleColor }}
-        >
-          {subtitle || 'Sözümüze Hoşgeldiniz...'}
-        </p>
-        <h1
+          pos={subtitlePos}
+          onPosChange={onSubtitlePosChange}
+        />
+        <DraggableEditableText
+          text={title || 'Burcu & Fatih'}
+          onChange={onTitleChange}
           className={`text-3xl font-bold mb-8 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
           style={{ color: titleColor }}
-        >
-          {title || 'Burcu & Fatih'}
-        </h1>
-        <p
+          pos={titlePos}
+          onPosChange={onTitlePosChange}
+        />
+        <DraggableEditableText
+          text={altText || 'Bizimkisi bir aşk hikayesi..'}
+          onChange={onAltTextChange}
           className={`text-sm mb-8 ${altFont ? `font-${altFont}` : 'font-sans'}`}
           style={{ color: altColor }}
-        >
-          {altText || 'Bizimkisi bir aşk hikayesi..'}
-        </p>
+          pos={altTextPos}
+          onPosChange={onAltTextPosChange}
+        />
       </div>
       <div className="p-4 text-center border-t">
         <p className="text-xs text-gray-500">

--- a/src/components/Preview/WebPreview.js
+++ b/src/components/Preview/WebPreview.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import DraggableEditableText from '../DraggableEditableText';
 
 const WebPreview = ({
   slug,
@@ -10,7 +11,16 @@ const WebPreview = ({
   subtitleFont,
   subtitleColor,
   altFont,
-  altColor
+  altColor,
+  onTitleChange,
+  onSubtitleChange,
+  onAltTextChange,
+  titlePos,
+  subtitlePos,
+  altTextPos,
+  onTitlePosChange,
+  onSubtitlePosChange,
+  onAltTextPosChange,
 }) => (
   <div className="flex flex-col w-full max-w-xl h-[600px] bg-white rounded-lg shadow-xl overflow-hidden border border-gray-200">
     <div className="bg-gray-100 flex items-center px-4 py-2 space-x-1 border-b">
@@ -22,24 +32,30 @@ const WebPreview = ({
       </p>
     </div>
     <div className="flex-1 flex flex-col items-center justify-center text-center px-10 relative">
-      <p
+      <DraggableEditableText
+        text={subtitle || 'Sözümüze Hoşgeldiniz...'}
+        onChange={onSubtitleChange}
         className={`italic text-xl mb-4 ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
         style={{ color: subtitleColor }}
-      >
-        {subtitle || 'Sözümüze Hoşgeldiniz...'}
-      </p>
-      <h1
+        pos={subtitlePos}
+        onPosChange={onSubtitlePosChange}
+      />
+      <DraggableEditableText
+        text={title || 'Burcu & Fatih'}
+        onChange={onTitleChange}
         className={`text-5xl font-bold mb-3 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
         style={{ color: titleColor }}
-      >
-        {title || 'Burcu & Fatih'}
-      </h1>
-      <p
+        pos={titlePos}
+        onPosChange={onTitlePosChange}
+      />
+      <DraggableEditableText
+        text={altText || 'Bizimkisi bir aşk hikayesi..'}
+        onChange={onAltTextChange}
         className={`text-base mt-4 ${altFont ? `font-${altFont}` : 'font-sans'}`}
         style={{ color: altColor }}
-      >
-        {altText || 'Bizimkisi bir aşk hikayesi..'}
-      </p>
+        pos={altTextPos}
+        onPosChange={onAltTextPosChange}
+      />
       <svg
         className="w-8 h-8 text-gray-500 absolute bottom-4 animate-bounce"
         fill="none"

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -34,6 +34,9 @@ const DashboardPage = () => {
   const [altText, setAltText] = useState('');
   const [altFont, setAltFont] = useState('sans');
   const [altColor, setAltColor] = useState('#888888');
+  const [titlePos, setTitlePos] = useState({ x: 0, y: 0 });
+  const [subtitlePos, setSubtitlePos] = useState({ x: 0, y: 0 });
+  const [altTextPos, setAltTextPos] = useState({ x: 0, y: 0 });
   const [videoLink, setVideoLink] = useState('');
   const [slugExists, setSlugExists] = useState(false);
   const [slugMessage, setSlugMessage] = useState('');
@@ -142,6 +145,9 @@ const deleteCollection = async (collectionRef) => {
       altText,
       altFont,
       altColor,
+      titlePos,
+      subtitlePos,
+      altTextPos,
       videoLink,
       createdAt: new Date(),
     });
@@ -151,7 +157,11 @@ const deleteCollection = async (collectionRef) => {
     setSlug('');
     setTitle('');
     setSubtitle('');
+    setTitlePos({ x: 0, y: 0 });
+    setSubtitlePos({ x: 0, y: 0 });
+    setAltTextPos({ x: 0, y: 0 });
     setVideoLink('');
+    setAltText('');
   };
 
   const handleLogout = async () => {
@@ -227,6 +237,15 @@ const deleteCollection = async (collectionRef) => {
               subtitleColor={subtitleColor}
               altFont={altFont}
               altColor={altColor}
+              onTitleChange={setTitle}
+              onSubtitleChange={setSubtitle}
+              onAltTextChange={setAltText}
+              titlePos={titlePos}
+              subtitlePos={subtitlePos}
+              altTextPos={altTextPos}
+              onTitlePosChange={setTitlePos}
+              onSubtitlePosChange={setSubtitlePos}
+              onAltTextPosChange={setAltTextPos}
             />
           ) : (
             <WebPreview
@@ -240,6 +259,15 @@ const deleteCollection = async (collectionRef) => {
               subtitleColor={subtitleColor}
               altFont={altFont}
               altColor={altColor}
+              onTitleChange={setTitle}
+              onSubtitleChange={setSubtitle}
+              onAltTextChange={setAltText}
+              titlePos={titlePos}
+              subtitlePos={subtitlePos}
+              altTextPos={altTextPos}
+              onTitlePosChange={setTitlePos}
+              onSubtitlePosChange={setSubtitlePos}
+              onAltTextPosChange={setAltTextPos}
             />
           )}
         </div>
@@ -450,6 +478,9 @@ const deleteCollection = async (collectionRef) => {
                     setSubtitleFont(p.subtitleFont || 'sans');
                     setVideoLink(p.videoLink || '');
                     setAltText(p.altText || '');
+                    setTitlePos(p.titlePos || { x: 0, y: 0 });
+                    setSubtitlePos(p.subtitlePos || { x: 0, y: 0 });
+                    setAltTextPos(p.altTextPos || { x: 0, y: 0 });
                   }}
                   className="bg-yellow-500 hover:bg-yellow-600 text-white text-sm px-3 py-1 rounded shadow"
                 >
@@ -561,6 +592,9 @@ const deleteCollection = async (collectionRef) => {
                       altText,
                       altFont,
                       altColor,
+                      titlePos,
+                      subtitlePos,
+                      altTextPos,
                       videoLink
                     });
                      <p className="text-green-600 mb-4">✅ Mesajınız başarıyla gönderildi 🎉</p>

--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -41,6 +41,9 @@ const HeroPage = () => {
   const [subtitleColor, setSubtitleColor] = useState('#555555');
   const [altFont, setAltFont] = useState('modern');
   const [altColor, setAltColor] = useState('#888888');
+  const [titlePos, setTitlePos] = useState({ x: 0, y: 0 });
+  const [subtitlePos, setSubtitlePos] = useState({ x: 0, y: 0 });
+  const [altTextPos, setAltTextPos] = useState({ x: 0, y: 0 });
   
   // QR Kod ve paylaşım state'leri
   const [showQRModal, setShowQRModal] = useState(false);
@@ -152,7 +155,10 @@ const HeroPage = () => {
         subtitleFont,
         subtitleColor,
         altFont,
-        altColor
+        altColor,
+        titlePos,
+        subtitlePos,
+        altTextPos
       });
 
       // Kullanıcıyı initialized olarak işaretle
@@ -192,6 +198,9 @@ const HeroPage = () => {
     setSubtitleColor('#555555');
     setAltFont('sans');
     setAltColor('#888888');
+    setTitlePos({ x: 0, y: 0 });
+    setSubtitlePos({ x: 0, y: 0 });
+    setAltTextPos({ x: 0, y: 0 });
   };
 
   const handleShare = async () => {
@@ -310,6 +319,15 @@ const HeroPage = () => {
               subtitleColor={subtitleColor}
               altFont={altFont}
               altColor={altColor}
+              onTitleChange={setTitle}
+              onSubtitleChange={setSubtitle}
+              onAltTextChange={setAltText}
+              titlePos={titlePos}
+              subtitlePos={subtitlePos}
+              altTextPos={altTextPos}
+              onTitlePosChange={setTitlePos}
+              onSubtitlePosChange={setSubtitlePos}
+              onAltTextPosChange={setAltTextPos}
             />
           ) : (
             <WebPreview
@@ -323,6 +341,15 @@ const HeroPage = () => {
               subtitleColor={subtitleColor}
               altFont={altFont}
               altColor={altColor}
+              onTitleChange={setTitle}
+              onSubtitleChange={setSubtitle}
+              onAltTextChange={setAltText}
+              titlePos={titlePos}
+              subtitlePos={subtitlePos}
+              altTextPos={altTextPos}
+              onTitlePosChange={setTitlePos}
+              onSubtitlePosChange={setSubtitlePos}
+              onAltTextPosChange={setAltTextPos}
             />
           )}
         </div>

--- a/src/pages/SlugPage.js
+++ b/src/pages/SlugPage.js
@@ -51,15 +51,42 @@ useEffect(() => {
     <div className="min-h-screen bg-white px-4 py-8">
       {/* Hero Section */}
       <section className="min-h-screen flex flex-col justify-center items-center text-center relative">
-        <p className={`italic text-xl font-${page.subtitleFont} mb-4`} style={{ color: page.subtitleColor }}>
-          {page.subtitle}
-        </p>
-        <h1 className={`text-5xl font-${page.titleFont} mb-3`} style={{ color: page.titleColor }}>
-          {page.title}
-        </h1>
-        <p className={`text-base font-${page.altFont} mt-4`} style={{ color: page.altColor }}>
-          {page.altText}
-        </p>
+        {page.subtitlePos ? (
+          <p
+            className={`italic text-xl font-${page.subtitleFont} mb-4 absolute`}
+            style={{ color: page.subtitleColor, left: page.subtitlePos.x, top: page.subtitlePos.y }}
+          >
+            {page.subtitle}
+          </p>
+        ) : (
+          <p className={`italic text-xl font-${page.subtitleFont} mb-4`} style={{ color: page.subtitleColor }}>
+            {page.subtitle}
+          </p>
+        )}
+        {page.titlePos ? (
+          <h1
+            className={`text-5xl font-${page.titleFont} mb-3 absolute`}
+            style={{ color: page.titleColor, left: page.titlePos.x, top: page.titlePos.y }}
+          >
+            {page.title}
+          </h1>
+        ) : (
+          <h1 className={`text-5xl font-${page.titleFont} mb-3`} style={{ color: page.titleColor }}>
+            {page.title}
+          </h1>
+        )}
+        {page.altTextPos ? (
+          <p
+            className={`text-base font-${page.altFont} mt-4 absolute`}
+            style={{ color: page.altColor, left: page.altTextPos.x, top: page.altTextPos.y }}
+          >
+            {page.altText}
+          </p>
+        ) : (
+          <p className={`text-base font-${page.altFont} mt-4`} style={{ color: page.altColor }}>
+            {page.altText}
+          </p>
+        )}
 
         {/* Scroll down arrow */}
         <button


### PR DESCRIPTION
## Summary
- add `DraggableEditableText` component for moving and editing text
- use `DraggableEditableText` in phone and web previews
- keep form fields in sync by passing callbacks from pages
- store positions in Firestore and load them on slug pages

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68892d205f10832d9f4cfd08cc9b7224