### PR TITLE
Fix preview positioning and dashboard UX

### DIFF
--- a/src/components/DraggableEditableText.js
+++ b/src/components/DraggableEditableText.js
@@ -35,11 +35,20 @@ const DraggableEditableText = ({
     document.addEventListener('mouseup', handleMouseUp);
   };
 
+  const isDefault = position.x === 0 && position.y === 0;
+
   return (
     <span
       onMouseDown={handleMouseDown}
       onDoubleClick={() => setEditing(true)}
-      style={{ position: 'absolute', left: position.x, top: position.y, cursor: editing ? 'text' : 'move', ...style }}
+      style={{
+        position: 'absolute',
+        left: isDefault ? '50%' : position.x,
+        top: isDefault ? '50%' : position.y,
+        transform: isDefault ? 'translate(-50%, -50%)' : undefined,
+        cursor: editing ? 'text' : 'move',
+        ...style,
+      }}
       className={className}
     >
       {editing ? (

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -43,6 +43,7 @@ const DashboardPage = () => {
   const [qrModalOpen, setQrModalOpen] = useState(false);
   const [qrValue, setQrValue] = useState('');
   const [previewType, setPreviewType] = useState('phone');
+  const [updating, setUpdating] = useState(false);
 
 const qrRef = useRef(null);
 const invalidSlugRegex = /[^a-zA-Z-]/;
@@ -432,12 +433,14 @@ const deleteCollection = async (collectionRef) => {
           onChange={(e) => setVideoLink(e.target.value)}
         />
         </div>
-        <button
-          onClick={handleSave}
-          className="bg-green-600 hover:bg-green-700 text-white w-full py-2 rounded shadow"
-        >
-          🚀 Sayfa Kaydet
-        </button>
+        {editingSlug === null && (
+          <button
+            onClick={handleSave}
+            className="bg-green-600 hover:bg-green-700 text-white w-full py-2 rounded shadow"
+          >
+            🚀 Sayfa Kaydet
+          </button>
+        )}
 
           {pages.length > 0 && (
             <div className="bg-gray-100 rounded p-4 mt-6">
@@ -581,6 +584,7 @@ const deleteCollection = async (collectionRef) => {
                 </div>
                 <button
                   onClick={async () => {
+                    setUpdating(true);
                     const ref = doc(db, 'users', user.uid, 'pages', p.slug);
                     await updateDoc(ref, {
                       title,
@@ -597,11 +601,13 @@ const deleteCollection = async (collectionRef) => {
                       altTextPos,
                       videoLink
                     });
-                     <p className="text-green-600 mb-4">✅ Mesajınız başarıyla gönderildi 🎉</p>
+                    toast.success('Sayfa güncellendi!');
                     setEditingSlug(null);
                     fetchUserPages();
+                    setUpdating(false);
                   }}
-                  className="bg-blue-600 text-white px-4 py-2 rounded shadow"
+                  className={`bg-blue-600 text-white px-4 py-2 rounded shadow ${updating ? 'animate-pulse' : ''}`}
+                  disabled={updating}
                 >
                   💾 Güncelle
                 </button>

--- a/src/pages/SlugPage.js
+++ b/src/pages/SlugPage.js
@@ -54,7 +54,13 @@ useEffect(() => {
         {page.subtitlePos ? (
           <p
             className={`italic text-xl font-${page.subtitleFont} mb-4 absolute`}
-            style={{ color: page.subtitleColor, left: page.subtitlePos.x, top: page.subtitlePos.y }}
+            style={{
+              color: page.subtitleColor,
+              left: page.subtitlePos.x === 0 && page.subtitlePos.y === 0 ? '50%' : page.subtitlePos.x,
+              top: page.subtitlePos.x === 0 && page.subtitlePos.y === 0 ? '50%' : page.subtitlePos.y,
+              transform:
+                page.subtitlePos.x === 0 && page.subtitlePos.y === 0 ? 'translate(-50%, -50%)' : undefined,
+            }}
           >
             {page.subtitle}
           </p>
@@ -66,7 +72,13 @@ useEffect(() => {
         {page.titlePos ? (
           <h1
             className={`text-5xl font-${page.titleFont} mb-3 absolute`}
-            style={{ color: page.titleColor, left: page.titlePos.x, top: page.titlePos.y }}
+            style={{
+              color: page.titleColor,
+              left: page.titlePos.x === 0 && page.titlePos.y === 0 ? '50%' : page.titlePos.x,
+              top: page.titlePos.x === 0 && page.titlePos.y === 0 ? '50%' : page.titlePos.y,
+              transform:
+                page.titlePos.x === 0 && page.titlePos.y === 0 ? 'translate(-50%, -50%)' : undefined,
+            }}
           >
             {page.title}
           </h1>
@@ -78,7 +90,13 @@ useEffect(() => {
         {page.altTextPos ? (
           <p
             className={`text-base font-${page.altFont} mt-4 absolute`}
-            style={{ color: page.altColor, left: page.altTextPos.x, top: page.altTextPos.y }}
+            style={{
+              color: page.altColor,
+              left: page.altTextPos.x === 0 && page.altTextPos.y === 0 ? '50%' : page.altTextPos.x,
+              top: page.altTextPos.x === 0 && page.altTextPos.y === 0 ? '50%' : page.altTextPos.y,
+              transform:
+                page.altTextPos.x === 0 && page.altTextPos.y === 0 ? 'translate(-50%, -50%)' : undefined,
+            }}
           >
             {page.altText}
           </p>


### PR DESCRIPTION
## Summary
- keep draggable text centered when it hasn't been moved
- hide save button while editing a page
- show toast and animation when updating a page
- center text on live pages when position is not set

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68893496ff98832da5e8f1f50063b7b3