### PR TITLE
Fix preview text positions

### DIFF
--- a/src/components/DraggableText.js
+++ b/src/components/DraggableText.js
@@ -1,16 +1,22 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
-const DraggableText = ({ children, style, className, ...rest }) => {
-  const [pos, setPos] = useState({ x: 0, y: 0 });
+const DraggableText = ({ children, style, className, pos = { x: 0, y: 0 }, onPosChange, ...rest }) => {
+  const [internalPos, setInternalPos] = useState(pos);
+
+  useEffect(() => {
+    setInternalPos(pos);
+  }, [pos]);
 
   const startDrag = (clientX, clientY) => {
-    const startX = clientX - pos.x;
-    const startY = clientY - pos.y;
+    const startX = clientX - internalPos.x;
+    const startY = clientY - internalPos.y;
 
     const onMove = (moveEvent) => {
       const x = moveEvent.clientX !== undefined ? moveEvent.clientX : moveEvent.touches[0].clientX;
       const y = moveEvent.clientY !== undefined ? moveEvent.clientY : moveEvent.touches[0].clientY;
-      setPos({ x: x - startX, y: y - startY });
+      const newPos = { x: x - startX, y: y - startY };
+      setInternalPos(newPos);
+      if (onPosChange) onPosChange(newPos);
     };
 
     const endMove = () => {
@@ -39,7 +45,7 @@ const DraggableText = ({ children, style, className, ...rest }) => {
     <div
       onMouseDown={handleMouseDown}
       onTouchStart={handleTouchStart}
-      style={{ position: 'relative', left: pos.x, top: pos.y, cursor: 'move', ...style }}
+      style={{ position: 'relative', left: internalPos.x, top: internalPos.y, cursor: 'move', ...style }}
       className={className}
       {...rest}
     >

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -34,6 +34,9 @@ const DashboardPage = () => {
   const [altText, setAltText] = useState('');
   const [altFont, setAltFont] = useState('sans');
   const [altColor, setAltColor] = useState('#888888');
+  const [subtitlePos, setSubtitlePos] = useState({ x: 0, y: 0 });
+  const [titlePos, setTitlePos] = useState({ x: 0, y: 0 });
+  const [altPos, setAltPos] = useState({ x: 0, y: 0 });
   const [videoLink, setVideoLink] = useState('');
   const [backgroundImage, setBackgroundImage] = useState('');
   const [bgFile, setBgFile] = useState(null);
@@ -171,6 +174,9 @@ const deleteCollection = async (collectionRef) => {
       altText,
       altFont,
       altColor,
+      subtitlePos,
+      titlePos,
+      altPos,
       videoLink,
       backgroundImage,
       createdAt: new Date(),
@@ -181,6 +187,9 @@ const deleteCollection = async (collectionRef) => {
     setSlug('');
     setTitle('');
     setSubtitle('');
+    setSubtitlePos({ x: 0, y: 0 });
+    setTitlePos({ x: 0, y: 0 });
+    setAltPos({ x: 0, y: 0 });
     setVideoLink('');
     setBackgroundImage('');
     setBgPreview('');
@@ -455,18 +464,24 @@ const deleteCollection = async (collectionRef) => {
                   <DraggableText
                     className={`text-sm mb-8 italic ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
                     style={{ color: subtitleColor }}
+                    pos={subtitlePos}
+                    onPosChange={setSubtitlePos}
                   >
                     {subtitle || 'Sözümüze Hoşgeldiniz...'}
                   </DraggableText>
                   <DraggableText
                     className={`text-3xl font-bold mb-8 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
                     style={{ color: titleColor }}
+                    pos={titlePos}
+                    onPosChange={setTitlePos}
                   >
                     {title || 'Burcu & Fatih'}
                   </DraggableText>
                   <DraggableText
                     className={`text-sm mb-8 ${altFont ? `font-${altFont}` : 'font-sans'}`}
                     style={{ color: altColor }}
+                    pos={altPos}
+                    onPosChange={setAltPos}
                   >
                     {altText || 'Bizimkisi bir aşk hikayesi..'}
                   </DraggableText>
@@ -534,6 +549,9 @@ const deleteCollection = async (collectionRef) => {
                     setVideoLink(p.videoLink || '');
                     setAltText(p.altText || '');
                     setBackgroundImage(p.backgroundImage || '');
+                    setSubtitlePos(p.subtitlePos || { x: 0, y: 0 });
+                    setTitlePos(p.titlePos || { x: 0, y: 0 });
+                    setAltPos(p.altPos || { x: 0, y: 0 });
                     setBgPreview(p.backgroundImage || '');
                   }}
                   className="text-yellow-600 text-sm hover:underline"
@@ -678,6 +696,9 @@ const deleteCollection = async (collectionRef) => {
                       altText,
                       altFont,
                       altColor,
+                      subtitlePos,
+                      titlePos,
+                      altPos,
                       videoLink,
                       backgroundImage
                     });

--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -45,6 +45,9 @@ const HeroPage = () => {
   const [subtitleColor, setSubtitleColor] = useState('#555555');
   const [altFont, setAltFont] = useState('modern');
   const [altColor, setAltColor] = useState('#888888');
+  const [subtitlePos, setSubtitlePos] = useState({ x: 0, y: 0 });
+  const [titlePos, setTitlePos] = useState({ x: 0, y: 0 });
+  const [altPos, setAltPos] = useState({ x: 0, y: 0 });
   
   // QR Kod ve paylaşım state'leri
   const [showQRModal, setShowQRModal] = useState(false);
@@ -210,7 +213,10 @@ const HeroPage = () => {
         subtitleFont,
         subtitleColor,
         altFont,
-        altColor
+        altColor,
+        subtitlePos,
+        titlePos,
+        altPos
       });
 
       // Kullanıcıyı initialized olarak işaretle
@@ -240,6 +246,9 @@ const HeroPage = () => {
     setTitle('');
     setSubtitle('');
     setAltText('');
+    setSubtitlePos({ x: 0, y: 0 });
+    setTitlePos({ x: 0, y: 0 });
+    setAltPos({ x: 0, y: 0 });
     setVideoLink('');
     setSlugExists(false);
     setSlugMessage('');
@@ -361,18 +370,24 @@ const HeroPage = () => {
                 <DraggableText
                   className={`text-sm mb-8 italic ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
                   style={{ color: subtitleColor }}
+                  pos={subtitlePos}
+                  onPosChange={setSubtitlePos}
                 >
                   {subtitle || 'Sözümüze Hoşgeldiniz...'}
                 </DraggableText>
                 <DraggableText
                   className={`text-3xl font-bold mb-8 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
                   style={{ color: titleColor }}
+                  pos={titlePos}
+                  onPosChange={setTitlePos}
                 >
                   {title || 'Burcu & Fatih'}
                 </DraggableText>
                 <DraggableText
                   className={`text-sm mb-8 ${altFont ? `font-${altFont}` : 'font-sans'}`}
                   style={{ color: altColor }}
+                  pos={altPos}
+                  onPosChange={setAltPos}
                 >
                   {altText || 'Bizimkisi bir aşk hikayesi..'}
                 </DraggableText>

--- a/src/pages/SlugPage.js
+++ b/src/pages/SlugPage.js
@@ -54,13 +54,22 @@ useEffect(() => {
         className="min-h-screen flex flex-col justify-center items-center text-center relative bg-cover bg-center"
         style={page.backgroundImage ? { backgroundImage: `url(${page.backgroundImage})` } : {}}
       >
-        <p className={`italic text-xl font-${page.subtitleFont} mb-4`} style={{ color: page.subtitleColor }}>
+        <p
+          className={`italic text-xl font-${page.subtitleFont}`}
+          style={{ color: page.subtitleColor, position: 'relative', left: page.subtitlePos?.x || 0, top: page.subtitlePos?.y || 0 }}
+        >
           {page.subtitle}
         </p>
-        <h1 className={`text-5xl font-${page.titleFont} mb-3`} style={{ color: page.titleColor }}>
+        <h1
+          className={`text-5xl font-${page.titleFont}`}
+          style={{ color: page.titleColor, position: 'relative', left: page.titlePos?.x || 0, top: page.titlePos?.y || 0 }}
+        >
           {page.title}
         </h1>
-        <p className={`text-base font-${page.altFont} mt-4`} style={{ color: page.altColor }}>
+        <p
+          className={`text-base font-${page.altFont}`}
+          style={{ color: page.altColor, position: 'relative', left: page.altPos?.x || 0, top: page.altPos?.y || 0 }}
+        >
           {page.altText}
         </p>
 


### PR DESCRIPTION
## Summary
- track text positions in `DraggableText`
- preserve dragged positions in dashboard and hero pages
- store positions in Firestore and apply them on slug page

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688ba41de068832d9f2ff7087ed8fe16