### PR TITLE
Fix preview text overlaps

### DIFF
--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -41,9 +41,15 @@ const HeroPage = () => {
   const [subtitleColor, setSubtitleColor] = useState('#555555');
   const [altFont, setAltFont] = useState('modern');
   const [altColor, setAltColor] = useState('#888888');
-  const [titlePos, setTitlePos] = useState({ x: 0, y: 0 });
-  const [subtitlePos, setSubtitlePos] = useState({ x: 0, y: 0 });
-  const [altTextPos, setAltTextPos] = useState({ x: 0, y: 0 });
+  const DEFAULT_POSITIONS = {
+    title: { x: 188, y: 300 },
+    subtitle: { x: 188, y: 200 },
+    altText: { x: 188, y: 400 },
+  };
+
+  const [titlePos, setTitlePos] = useState(DEFAULT_POSITIONS.title);
+  const [subtitlePos, setSubtitlePos] = useState(DEFAULT_POSITIONS.subtitle);
+  const [altTextPos, setAltTextPos] = useState(DEFAULT_POSITIONS.altText);
 
   // QR Kod ve paylaşım state'leri
   const [showQRModal, setShowQRModal] = useState(false);
@@ -222,9 +228,9 @@ const HeroPage = () => {
     setSubtitleColor('#555555');
     setAltFont('sans');
     setAltColor('#888888');
-    setTitlePos({ x: 0, y: 0 });
-    setSubtitlePos({ x: 0, y: 0 });
-    setAltTextPos({ x: 0, y: 0 });
+    setTitlePos(DEFAULT_POSITIONS.title);
+    setSubtitlePos(DEFAULT_POSITIONS.subtitle);
+    setAltTextPos(DEFAULT_POSITIONS.altText);
   };
 
   const handleShare = async () => {


### PR DESCRIPTION
## Summary
- set default text positions for modal preview
- keep defaults when modal is reset

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_688ba953a438832db87b1cc29dcb50f1