### PR TITLE
Fix preview text overlaps

### DIFF
--- a/src/components/DraggableEditableText.js
+++ b/src/components/DraggableEditableText.js
@@ -7,6 +7,7 @@ const DraggableEditableText = ({
   style,
   pos = { x: 0, y: 0 },
   onPosChange,
+  centerX = false,
 }) => {
   const [editing, setEditing] = useState(false);
   const [position, setPosition] = useState(pos);
@@ -43,9 +44,15 @@ const DraggableEditableText = ({
       onDoubleClick={() => setEditing(true)}
       style={{
         position: 'absolute',
-        left: isDefault ? '50%' : position.x,
+        left: centerX ? position.x : isDefault ? '50%' : position.x,
         top: isDefault ? '50%' : position.y,
-        transform: isDefault ? 'translate(-50%, -50%)' : undefined,
+        transform: [
+          centerX && 'translateX(-50%)',
+          isDefault && 'translateY(-50%)',
+          !centerX && isDefault && 'translateX(-50%)',
+        ]
+          .filter(Boolean)
+          .join(' '),
         cursor: editing ? 'text' : 'move',
         ...style,
       }}

--- a/src/components/Preview/PhonePreview.js
+++ b/src/components/Preview/PhonePreview.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import DraggableEditableText from '../DraggableEditableText';
 
-const PhonePreview = ({
+const PhonePreview = React.forwardRef(({
   slug,
   title,
   subtitle,
@@ -21,8 +21,8 @@ const PhonePreview = ({
   onTitlePosChange,
   onSubtitlePosChange,
   onAltTextPosChange,
-}) => (
-  <div className="block w-full max-w-[375px] h-[700px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white relative">
+}, ref) => (
+  <div ref={ref} className="block w-full max-w-[375px] h-[700px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white relative">
     <div className="h-full flex flex-col">
       <div className="flex-1 p-8 flex flex-col items-center justify-center text-center relative">
         <DraggableEditableText
@@ -32,6 +32,7 @@ const PhonePreview = ({
           style={{ color: subtitleColor }}
           pos={subtitlePos}
           onPosChange={onSubtitlePosChange}
+          centerX
         />
         <DraggableEditableText
           text={title || 'Burcu & Fatih'}
@@ -40,6 +41,7 @@ const PhonePreview = ({
           style={{ color: titleColor }}
           pos={titlePos}
           onPosChange={onTitlePosChange}
+          centerX
         />
         <DraggableEditableText
           text={altText || 'Bizimkisi bir aşk hikayesi..'}
@@ -48,6 +50,7 @@ const PhonePreview = ({
           style={{ color: altColor }}
           pos={altTextPos}
           onPosChange={onAltTextPosChange}
+          centerX
         />
       </div>
       <div className="p-4 text-center border-t">
@@ -57,6 +60,6 @@ const PhonePreview = ({
       </div>
     </div>
   </div>
-);
+));
 
 export default PhonePreview;

--- a/src/components/Preview/WebPreview.js
+++ b/src/components/Preview/WebPreview.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import DraggableEditableText from '../DraggableEditableText';
 
-const WebPreview = ({
+const WebPreview = React.forwardRef(({
   slug,
   title,
   subtitle,
@@ -21,8 +21,8 @@ const WebPreview = ({
   onTitlePosChange,
   onSubtitlePosChange,
   onAltTextPosChange,
-}) => (
-  <div className="flex flex-col w-full max-w-[640px] h-[720px] bg-white rounded-lg shadow-xl overflow-hidden border border-gray-200">
+}, ref) => (
+  <div ref={ref} className="flex flex-col w-full max-w-[640px] h-[720px] bg-white rounded-lg shadow-xl overflow-hidden border border-gray-200">
     <div className="bg-gray-100 flex items-center px-4 py-2 space-x-1 border-b">
       <span className="w-3 h-3 bg-red-500 rounded-full" />
       <span className="w-3 h-3 bg-yellow-500 rounded-full" />
@@ -39,6 +39,7 @@ const WebPreview = ({
         style={{ color: subtitleColor }}
         pos={subtitlePos}
         onPosChange={onSubtitlePosChange}
+        centerX
       />
       <DraggableEditableText
         text={title || 'Burcu & Fatih'}
@@ -47,6 +48,7 @@ const WebPreview = ({
         style={{ color: titleColor }}
         pos={titlePos}
         onPosChange={onTitlePosChange}
+        centerX
       />
       <DraggableEditableText
         text={altText || 'Bizimkisi bir aşk hikayesi..'}
@@ -55,6 +57,7 @@ const WebPreview = ({
         style={{ color: altColor }}
         pos={altTextPos}
         onPosChange={onAltTextPosChange}
+        centerX
       />
       <svg
         className="w-8 h-8 text-gray-500 absolute bottom-4 animate-bounce"
@@ -67,6 +70,6 @@ const WebPreview = ({
       </svg>
     </div>
   </div>
-);
+));
 
 export default WebPreview;

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -37,6 +37,17 @@ const DashboardPage = () => {
   const [titlePos, setTitlePos] = useState({ x: 0, y: 0 });
   const [subtitlePos, setSubtitlePos] = useState({ x: 0, y: 0 });
   const [altTextPos, setAltTextPos] = useState({ x: 0, y: 0 });
+  const previewRef = useRef(null);
+  const DEFAULT_RATIOS = {
+    title: 0.43,
+    subtitle: 0.29,
+    altText: 0.57,
+  };
+  const defaultPositions = useRef({
+    title: { x: 0, y: 0 },
+    subtitle: { x: 0, y: 0 },
+    altText: { x: 0, y: 0 },
+  });
   const [videoLink, setVideoLink] = useState('');
   const [slugExists, setSlugExists] = useState(false);
   const [slugMessage, setSlugMessage] = useState('');
@@ -66,6 +77,29 @@ const DashboardPage = () => {
     setSubtitlePos((p) => scale(p));
     setAltTextPos((p) => scale(p));
     prevPreviewTypeRef.current = previewType;
+  }, [previewType]);
+
+  useEffect(() => {
+    const computeDefaults = () => {
+      const rect = previewRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const { width, height } = rect;
+      const updated = {
+        title: { x: width / 2, y: height * DEFAULT_RATIOS.title },
+        subtitle: { x: width / 2, y: height * DEFAULT_RATIOS.subtitle },
+        altText: { x: width / 2, y: height * DEFAULT_RATIOS.altText },
+      };
+      defaultPositions.current = updated;
+      setTitlePos((p) => (p.x === 0 && p.y === 0 ? updated.title : p));
+      setSubtitlePos((p) => (p.x === 0 && p.y === 0 ? updated.subtitle : p));
+      setAltTextPos((p) => (p.x === 0 && p.y === 0 ? updated.altText : p));
+    };
+    const id = requestAnimationFrame(computeDefaults);
+    window.addEventListener('resize', computeDefaults);
+    return () => {
+      cancelAnimationFrame(id);
+      window.removeEventListener('resize', computeDefaults);
+    };
   }, [previewType]);
   const [updating, setUpdating] = useState(false);
 
@@ -182,9 +216,9 @@ const deleteCollection = async (collectionRef) => {
     setSlug('');
     setTitle('');
     setSubtitle('');
-    setTitlePos({ x: 0, y: 0 });
-    setSubtitlePos({ x: 0, y: 0 });
-    setAltTextPos({ x: 0, y: 0 });
+    setTitlePos(defaultPositions.current.title);
+    setSubtitlePos(defaultPositions.current.subtitle);
+    setAltTextPos(defaultPositions.current.altText);
     setVideoLink('');
     setAltText('');
   };
@@ -252,6 +286,7 @@ const deleteCollection = async (collectionRef) => {
           </div>
           {previewType === 'phone' ? (
             <PhonePreview
+              ref={previewRef}
               slug={slug}
               title={title}
               subtitle={subtitle}
@@ -274,6 +309,7 @@ const deleteCollection = async (collectionRef) => {
             />
           ) : (
             <WebPreview
+              ref={previewRef}
               slug={slug}
               title={title}
               subtitle={subtitle}
@@ -505,9 +541,9 @@ const deleteCollection = async (collectionRef) => {
                     setSubtitleFont(p.subtitleFont || 'sans');
                     setVideoLink(p.videoLink || '');
                     setAltText(p.altText || '');
-                    setTitlePos(p.titlePos || { x: 0, y: 0 });
-                    setSubtitlePos(p.subtitlePos || { x: 0, y: 0 });
-                    setAltTextPos(p.altTextPos || { x: 0, y: 0 });
+                    setTitlePos(p.titlePos || defaultPositions.current.title);
+                    setSubtitlePos(p.subtitlePos || defaultPositions.current.subtitle);
+                    setAltTextPos(p.altTextPos || defaultPositions.current.altText);
                   }}
                   className="bg-yellow-500 hover:bg-yellow-600 text-white text-sm px-3 py-1 rounded shadow"
                 >

--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -41,6 +41,18 @@ const HeroPage = () => {
   const [subtitleColor, setSubtitleColor] = useState('#555555');
   const [altFont, setAltFont] = useState('modern');
   const [altColor, setAltColor] = useState('#888888');
+  const previewRef = useRef(null);
+  const DEFAULT_RATIOS = {
+    title: 0.43,
+    subtitle: 0.29,
+    altText: 0.57,
+  };
+  const defaultPositions = useRef({
+    title: { x: 0, y: 0 },
+    subtitle: { x: 0, y: 0 },
+    altText: { x: 0, y: 0 },
+  });
+
   const [titlePos, setTitlePos] = useState({ x: 0, y: 0 });
   const [subtitlePos, setSubtitlePos] = useState({ x: 0, y: 0 });
   const [altTextPos, setAltTextPos] = useState({ x: 0, y: 0 });
@@ -73,6 +85,30 @@ const HeroPage = () => {
     setAltTextPos((p) => scale(p));
     prevPreviewTypeRef.current = previewType;
   }, [previewType]);
+
+  useEffect(() => {
+    if (!showModal) return;
+    const computeDefaults = () => {
+      const rect = previewRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const { width, height } = rect;
+      const updated = {
+        title: { x: width / 2, y: height * DEFAULT_RATIOS.title },
+        subtitle: { x: width / 2, y: height * DEFAULT_RATIOS.subtitle },
+        altText: { x: width / 2, y: height * DEFAULT_RATIOS.altText },
+      };
+      defaultPositions.current = updated;
+      setTitlePos(updated.title);
+      setSubtitlePos(updated.subtitle);
+      setAltTextPos(updated.altText);
+    };
+    const id = requestAnimationFrame(computeDefaults);
+    window.addEventListener('resize', computeDefaults);
+    return () => {
+      cancelAnimationFrame(id);
+      window.removeEventListener('resize', computeDefaults);
+    };
+  }, [showModal]);
 
 
   useEffect(() => {
@@ -222,9 +258,9 @@ const HeroPage = () => {
     setSubtitleColor('#555555');
     setAltFont('sans');
     setAltColor('#888888');
-    setTitlePos({ x: 0, y: 0 });
-    setSubtitlePos({ x: 0, y: 0 });
-    setAltTextPos({ x: 0, y: 0 });
+    setTitlePos(defaultPositions.current.title);
+    setSubtitlePos(defaultPositions.current.subtitle);
+    setAltTextPos(defaultPositions.current.altText);
   };
 
   const handleShare = async () => {
@@ -333,6 +369,7 @@ const HeroPage = () => {
           </div>
           {previewType === 'phone' ? (
             <PhonePreview
+              ref={previewRef}
               slug={slug}
               title={title}
               subtitle={subtitle}
@@ -355,6 +392,7 @@ const HeroPage = () => {
             />
           ) : (
             <WebPreview
+              ref={previewRef}
               slug={slug}
               title={title}
               subtitle={subtitle}


### PR DESCRIPTION
## Summary
- compute default text positions using live preview size
- forward refs through preview components for measuring
- center preview text horizontally when modal opens
- compute positions and centering logic inside DashboardPage

## Testing
- `CI=true npm test --silent --yes -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688ba953a438832db87b1cc29dcb50f1