### PR TITLE
Fix slugpage text offsets

### DIFF
--- a/src/components/DraggableEditableText.js
+++ b/src/components/DraggableEditableText.js
@@ -7,6 +7,7 @@ const DraggableEditableText = ({
   style,
   pos = { x: 0, y: 0 },
   onPosChange,
+  centerX = false,
 }) => {
   const [editing, setEditing] = useState(false);
   const [position, setPosition] = useState(pos);
@@ -43,9 +44,15 @@ const DraggableEditableText = ({
       onDoubleClick={() => setEditing(true)}
       style={{
         position: 'absolute',
-        left: isDefault ? '50%' : position.x,
+        left: centerX ? position.x : isDefault ? '50%' : position.x,
         top: isDefault ? '50%' : position.y,
-        transform: isDefault ? 'translate(-50%, -50%)' : undefined,
+        transform: [
+          centerX && 'translateX(-50%)',
+          isDefault && 'translateY(-50%)',
+          !centerX && isDefault && 'translateX(-50%)',
+        ]
+          .filter(Boolean)
+          .join(' '),
         cursor: editing ? 'text' : 'move',
         ...style,
       }}

--- a/src/components/Preview/PhonePreview.js
+++ b/src/components/Preview/PhonePreview.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import DraggableEditableText from '../DraggableEditableText';
 
-const PhonePreview = ({
+const PhonePreview = React.forwardRef(({
   slug,
   title,
   subtitle,
@@ -21,8 +21,8 @@ const PhonePreview = ({
   onTitlePosChange,
   onSubtitlePosChange,
   onAltTextPosChange,
-}) => (
-  <div className="block w-full max-w-[375px] h-[700px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white relative">
+}, ref) => (
+  <div ref={ref} className="block w-full max-w-[375px] h-[700px] bg-white rounded-3xl shadow-xl overflow-hidden border-8 border-white relative">
     <div className="h-full flex flex-col">
       <div className="flex-1 p-8 flex flex-col items-center justify-center text-center relative">
         <DraggableEditableText
@@ -32,6 +32,7 @@ const PhonePreview = ({
           style={{ color: subtitleColor }}
           pos={subtitlePos}
           onPosChange={onSubtitlePosChange}
+          centerX
         />
         <DraggableEditableText
           text={title || 'Burcu & Fatih'}
@@ -40,6 +41,7 @@ const PhonePreview = ({
           style={{ color: titleColor }}
           pos={titlePos}
           onPosChange={onTitlePosChange}
+          centerX
         />
         <DraggableEditableText
           text={altText || 'Bizimkisi bir aşk hikayesi..'}
@@ -48,6 +50,7 @@ const PhonePreview = ({
           style={{ color: altColor }}
           pos={altTextPos}
           onPosChange={onAltTextPosChange}
+          centerX
         />
       </div>
       <div className="p-4 text-center border-t">
@@ -57,6 +60,6 @@ const PhonePreview = ({
       </div>
     </div>
   </div>
-);
+));
 
 export default PhonePreview;

--- a/src/components/Preview/WebPreview.js
+++ b/src/components/Preview/WebPreview.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import DraggableEditableText from '../DraggableEditableText';
 
-const WebPreview = ({
+const WebPreview = React.forwardRef(({
   slug,
   title,
   subtitle,
@@ -21,8 +21,8 @@ const WebPreview = ({
   onTitlePosChange,
   onSubtitlePosChange,
   onAltTextPosChange,
-}) => (
-  <div className="flex flex-col w-full max-w-[640px] h-[720px] bg-white rounded-lg shadow-xl overflow-hidden border border-gray-200">
+}, ref) => (
+  <div ref={ref} className="flex flex-col w-full max-w-[640px] h-[720px] bg-white rounded-lg shadow-xl overflow-hidden border border-gray-200">
     <div className="bg-gray-100 flex items-center px-4 py-2 space-x-1 border-b">
       <span className="w-3 h-3 bg-red-500 rounded-full" />
       <span className="w-3 h-3 bg-yellow-500 rounded-full" />
@@ -39,6 +39,7 @@ const WebPreview = ({
         style={{ color: subtitleColor }}
         pos={subtitlePos}
         onPosChange={onSubtitlePosChange}
+        centerX
       />
       <DraggableEditableText
         text={title || 'Burcu & Fatih'}
@@ -47,6 +48,7 @@ const WebPreview = ({
         style={{ color: titleColor }}
         pos={titlePos}
         onPosChange={onTitlePosChange}
+        centerX
       />
       <DraggableEditableText
         text={altText || 'Bizimkisi bir aşk hikayesi..'}
@@ -55,6 +57,7 @@ const WebPreview = ({
         style={{ color: altColor }}
         pos={altTextPos}
         onPosChange={onAltTextPosChange}
+        centerX
       />
       <svg
         className="w-8 h-8 text-gray-500 absolute bottom-4 animate-bounce"
@@ -67,6 +70,6 @@ const WebPreview = ({
       </svg>
     </div>
   </div>
-);
+));
 
 export default WebPreview;

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -37,6 +37,17 @@ const DashboardPage = () => {
   const [titlePos, setTitlePos] = useState({ x: 0, y: 0 });
   const [subtitlePos, setSubtitlePos] = useState({ x: 0, y: 0 });
   const [altTextPos, setAltTextPos] = useState({ x: 0, y: 0 });
+  const previewRef = useRef(null);
+  const DEFAULT_RATIOS = {
+    title: 0.43,
+    subtitle: 0.29,
+    altText: 0.57,
+  };
+  const defaultPositions = useRef({
+    title: { x: 0, y: 0 },
+    subtitle: { x: 0, y: 0 },
+    altText: { x: 0, y: 0 },
+  });
   const [videoLink, setVideoLink] = useState('');
   const [slugExists, setSlugExists] = useState(false);
   const [slugMessage, setSlugMessage] = useState('');
@@ -66,6 +77,29 @@ const DashboardPage = () => {
     setSubtitlePos((p) => scale(p));
     setAltTextPos((p) => scale(p));
     prevPreviewTypeRef.current = previewType;
+  }, [previewType]);
+
+  useEffect(() => {
+    const computeDefaults = () => {
+      const rect = previewRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const { width, height } = rect;
+      const updated = {
+        title: { x: width / 2, y: height * DEFAULT_RATIOS.title },
+        subtitle: { x: width / 2, y: height * DEFAULT_RATIOS.subtitle },
+        altText: { x: width / 2, y: height * DEFAULT_RATIOS.altText },
+      };
+      defaultPositions.current = updated;
+      setTitlePos((p) => (p.x === 0 && p.y === 0 ? updated.title : p));
+      setSubtitlePos((p) => (p.x === 0 && p.y === 0 ? updated.subtitle : p));
+      setAltTextPos((p) => (p.x === 0 && p.y === 0 ? updated.altText : p));
+    };
+    const id = requestAnimationFrame(computeDefaults);
+    window.addEventListener('resize', computeDefaults);
+    return () => {
+      cancelAnimationFrame(id);
+      window.removeEventListener('resize', computeDefaults);
+    };
   }, [previewType]);
   const [updating, setUpdating] = useState(false);
 
@@ -182,9 +216,9 @@ const deleteCollection = async (collectionRef) => {
     setSlug('');
     setTitle('');
     setSubtitle('');
-    setTitlePos({ x: 0, y: 0 });
-    setSubtitlePos({ x: 0, y: 0 });
-    setAltTextPos({ x: 0, y: 0 });
+    setTitlePos(defaultPositions.current.title);
+    setSubtitlePos(defaultPositions.current.subtitle);
+    setAltTextPos(defaultPositions.current.altText);
     setVideoLink('');
     setAltText('');
   };
@@ -252,6 +286,7 @@ const deleteCollection = async (collectionRef) => {
           </div>
           {previewType === 'phone' ? (
             <PhonePreview
+              ref={previewRef}
               slug={slug}
               title={title}
               subtitle={subtitle}
@@ -274,6 +309,7 @@ const deleteCollection = async (collectionRef) => {
             />
           ) : (
             <WebPreview
+              ref={previewRef}
               slug={slug}
               title={title}
               subtitle={subtitle}
@@ -505,9 +541,9 @@ const deleteCollection = async (collectionRef) => {
                     setSubtitleFont(p.subtitleFont || 'sans');
                     setVideoLink(p.videoLink || '');
                     setAltText(p.altText || '');
-                    setTitlePos(p.titlePos || { x: 0, y: 0 });
-                    setSubtitlePos(p.subtitlePos || { x: 0, y: 0 });
-                    setAltTextPos(p.altTextPos || { x: 0, y: 0 });
+                    setTitlePos(p.titlePos || defaultPositions.current.title);
+                    setSubtitlePos(p.subtitlePos || defaultPositions.current.subtitle);
+                    setAltTextPos(p.altTextPos || defaultPositions.current.altText);
                   }}
                   className="bg-yellow-500 hover:bg-yellow-600 text-white text-sm px-3 py-1 rounded shadow"
                 >

--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -41,6 +41,18 @@ const HeroPage = () => {
   const [subtitleColor, setSubtitleColor] = useState('#555555');
   const [altFont, setAltFont] = useState('modern');
   const [altColor, setAltColor] = useState('#888888');
+  const previewRef = useRef(null);
+  const DEFAULT_RATIOS = {
+    title: 0.43,
+    subtitle: 0.29,
+    altText: 0.57,
+  };
+  const defaultPositions = useRef({
+    title: { x: 0, y: 0 },
+    subtitle: { x: 0, y: 0 },
+    altText: { x: 0, y: 0 },
+  });
+
   const [titlePos, setTitlePos] = useState({ x: 0, y: 0 });
   const [subtitlePos, setSubtitlePos] = useState({ x: 0, y: 0 });
   const [altTextPos, setAltTextPos] = useState({ x: 0, y: 0 });
@@ -73,6 +85,30 @@ const HeroPage = () => {
     setAltTextPos((p) => scale(p));
     prevPreviewTypeRef.current = previewType;
   }, [previewType]);
+
+  useEffect(() => {
+    if (!showModal) return;
+    const computeDefaults = () => {
+      const rect = previewRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const { width, height } = rect;
+      const updated = {
+        title: { x: width / 2, y: height * DEFAULT_RATIOS.title },
+        subtitle: { x: width / 2, y: height * DEFAULT_RATIOS.subtitle },
+        altText: { x: width / 2, y: height * DEFAULT_RATIOS.altText },
+      };
+      defaultPositions.current = updated;
+      setTitlePos(updated.title);
+      setSubtitlePos(updated.subtitle);
+      setAltTextPos(updated.altText);
+    };
+    const id = requestAnimationFrame(computeDefaults);
+    window.addEventListener('resize', computeDefaults);
+    return () => {
+      cancelAnimationFrame(id);
+      window.removeEventListener('resize', computeDefaults);
+    };
+  }, [showModal]);
 
 
   useEffect(() => {
@@ -222,9 +258,9 @@ const HeroPage = () => {
     setSubtitleColor('#555555');
     setAltFont('sans');
     setAltColor('#888888');
-    setTitlePos({ x: 0, y: 0 });
-    setSubtitlePos({ x: 0, y: 0 });
-    setAltTextPos({ x: 0, y: 0 });
+    setTitlePos(defaultPositions.current.title);
+    setSubtitlePos(defaultPositions.current.subtitle);
+    setAltTextPos(defaultPositions.current.altText);
   };
 
   const handleShare = async () => {
@@ -333,6 +369,7 @@ const HeroPage = () => {
           </div>
           {previewType === 'phone' ? (
             <PhonePreview
+              ref={previewRef}
               slug={slug}
               title={title}
               subtitle={subtitle}
@@ -355,6 +392,7 @@ const HeroPage = () => {
             />
           ) : (
             <WebPreview
+              ref={previewRef}
               slug={slug}
               title={title}
               subtitle={subtitle}

--- a/src/pages/SlugPage.js
+++ b/src/pages/SlugPage.js
@@ -10,6 +10,15 @@ const SlugPage = () => {
   const [page, setPage] = useState(null);
   const [loading, setLoading] = useState(true);
   const sectionRef = useRef(null);
+  const heroRef = useRef(null);
+  const PREVIEW_DIMENSIONS = {
+    phone: { width: 375, height: 700 },
+    web: { width: 640, height: 720 },
+  };
+  const DEFAULT_RATIOS = { title: 0.43, subtitle: 0.29, altText: 0.57 };
+  const [scaledTitlePos, setScaledTitlePos] = useState(null);
+  const [scaledSubtitlePos, setScaledSubtitlePos] = useState(null);
+  const [scaledAltTextPos, setScaledAltTextPos] = useState(null);
 
 useEffect(() => {
   if (!slug) {
@@ -44,67 +53,72 @@ useEffect(() => {
   fetchPage();
 }, [slug]);
 
+  useEffect(() => {
+    if (!page) return;
+    const computeScaled = () => {
+      const rect = heroRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const { width, height } = rect;
+      const base = width < 500 ? PREVIEW_DIMENSIONS.phone : PREVIEW_DIMENSIONS.web;
+      const scale = (pos, ratio) =>
+        pos
+          ? {
+              x: (pos.x * width) / base.width,
+              y: (pos.y * height) / base.height,
+            }
+          : { x: width / 2, y: height * ratio };
+      setScaledTitlePos(scale(page.titlePos, DEFAULT_RATIOS.title));
+      setScaledSubtitlePos(scale(page.subtitlePos, DEFAULT_RATIOS.subtitle));
+      setScaledAltTextPos(scale(page.altTextPos, DEFAULT_RATIOS.altText));
+    };
+    computeScaled();
+    window.addEventListener('resize', computeScaled);
+    return () => window.removeEventListener('resize', computeScaled);
+  }, [page]);
+
   if (loading) return <div className="text-center py-10">Yükleniyor...</div>;
   if (!page) return <div className="text-center py-10 text-red-600">Sayfa bulunamadı.</div>;
 
- return (
+  return (
     <div className="min-h-screen bg-white px-4 py-8">
       {/* Hero Section */}
-      <section className="min-h-screen flex flex-col justify-center items-center text-center relative">
-        {page.subtitlePos ? (
-          <p
-            className={`italic text-xl font-${page.subtitleFont} mb-4 absolute`}
-            style={{
-              color: page.subtitleColor,
-              left: page.subtitlePos.x === 0 && page.subtitlePos.y === 0 ? '50%' : page.subtitlePos.x,
-              top: page.subtitlePos.x === 0 && page.subtitlePos.y === 0 ? '50%' : page.subtitlePos.y,
-              transform:
-                page.subtitlePos.x === 0 && page.subtitlePos.y === 0 ? 'translate(-50%, -50%)' : undefined,
-            }}
-          >
-            {page.subtitle}
-          </p>
-        ) : (
-          <p className={`italic text-xl font-${page.subtitleFont} mb-4`} style={{ color: page.subtitleColor }}>
-            {page.subtitle}
-          </p>
-        )}
-        {page.titlePos ? (
-          <h1
-            className={`text-5xl font-${page.titleFont} mb-3 absolute`}
-            style={{
-              color: page.titleColor,
-              left: page.titlePos.x === 0 && page.titlePos.y === 0 ? '50%' : page.titlePos.x,
-              top: page.titlePos.x === 0 && page.titlePos.y === 0 ? '50%' : page.titlePos.y,
-              transform:
-                page.titlePos.x === 0 && page.titlePos.y === 0 ? 'translate(-50%, -50%)' : undefined,
-            }}
-          >
-            {page.title}
-          </h1>
-        ) : (
-          <h1 className={`text-5xl font-${page.titleFont} mb-3`} style={{ color: page.titleColor }}>
-            {page.title}
-          </h1>
-        )}
-        {page.altTextPos ? (
-          <p
-            className={`text-base font-${page.altFont} mt-4 absolute`}
-            style={{
-              color: page.altColor,
-              left: page.altTextPos.x === 0 && page.altTextPos.y === 0 ? '50%' : page.altTextPos.x,
-              top: page.altTextPos.x === 0 && page.altTextPos.y === 0 ? '50%' : page.altTextPos.y,
-              transform:
-                page.altTextPos.x === 0 && page.altTextPos.y === 0 ? 'translate(-50%, -50%)' : undefined,
-            }}
-          >
-            {page.altText}
-          </p>
-        ) : (
-          <p className={`text-base font-${page.altFont} mt-4`} style={{ color: page.altColor }}>
-            {page.altText}
-          </p>
-        )}
+      <section
+        ref={heroRef}
+        className="min-h-screen flex flex-col justify-center items-center text-center relative"
+      >
+        <p
+          className={`italic text-xl font-${page.subtitleFont} mb-4 absolute`}
+          style={{
+            color: page.subtitleColor,
+            left: scaledSubtitlePos?.x,
+            top: scaledSubtitlePos?.y,
+            transform: 'translateX(-50%)',
+          }}
+        >
+          {page.subtitle}
+        </p>
+        <h1
+          className={`text-5xl font-${page.titleFont} mb-3 absolute`}
+          style={{
+            color: page.titleColor,
+            left: scaledTitlePos?.x,
+            top: scaledTitlePos?.y,
+            transform: 'translateX(-50%)',
+          }}
+        >
+          {page.title}
+        </h1>
+        <p
+          className={`text-base font-${page.altFont} mt-4 absolute`}
+          style={{
+            color: page.altColor,
+            left: scaledAltTextPos?.x,
+            top: scaledAltTextPos?.y,
+            transform: 'translateX(-50%)',
+          }}
+        >
+          {page.altText}
+        </p>
 
         {/* Scroll down arrow */}
         <button


### PR DESCRIPTION
## Summary
- measure slug page hero section to get actual size
- scale saved text positions relative to measured dimensions
- horizontally center slug page texts with the scaled positions

## Testing
- `CI=true npm test --silent --yes -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688ba953a438832db87b1cc29dcb50f1