### PR TITLE
Add editable font sizes and placeholders

### DIFF
--- a/src/components/DraggableEditableText.js
+++ b/src/components/DraggableEditableText.js
@@ -8,6 +8,8 @@ const DraggableEditableText = ({
   pos = { x: 0, y: 0 },
   onPosChange,
   centerX = false,
+  placeholder = '',
+  touched = false,
 }) => {
   const [editing, setEditing] = useState(false);
   const [position, setPosition] = useState(pos);
@@ -61,13 +63,14 @@ const DraggableEditableText = ({
       {editing ? (
         <input
           value={text}
+          placeholder={placeholder}
           autoFocus
           onChange={(e) => onChange(e.target.value)}
           onBlur={() => setEditing(false)}
           className="border border-gray-300 rounded px-1"
         />
       ) : (
-        text
+        text || (!touched && placeholder)
       )}
     </span>
   );

--- a/src/components/Preview/PhonePreview.js
+++ b/src/components/Preview/PhonePreview.js
@@ -1,17 +1,23 @@
 import React from 'react';
 import DraggableEditableText from '../DraggableEditableText';
 
-const PhonePreview = React.forwardRef(({
+const PhonePreview = React.forwardRef(({ 
   slug,
   title,
   subtitle,
   altText,
   titleFont,
   titleColor,
+  titleSize,
   subtitleFont,
   subtitleColor,
+  subtitleSize,
   altFont,
   altColor,
+  altTextSize,
+  titleTouched,
+  subtitleTouched,
+  altTextTouched,
   onTitleChange,
   onSubtitleChange,
   onAltTextChange,
@@ -26,28 +32,34 @@ const PhonePreview = React.forwardRef(({
     <div className="h-full flex flex-col">
       <div className="flex-1 p-8 flex flex-col items-center justify-center text-center relative">
         <DraggableEditableText
-          text={subtitle || 'Sözümüze Hoşgeldiniz...'}
+          text={subtitle}
+          placeholder="Sözümüze Hoşgeldiniz..."
+          touched={subtitleTouched}
           onChange={onSubtitleChange}
-          className={`text-sm mb-8 italic ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
-          style={{ color: subtitleColor }}
+          className={`mb-8 italic ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
+          style={{ color: subtitleColor, fontSize: subtitleSize }}
           pos={subtitlePos}
           onPosChange={onSubtitlePosChange}
           centerX
         />
         <DraggableEditableText
-          text={title || 'Burcu & Fatih'}
+          text={title}
+          placeholder="Burcu & Fatih"
+          touched={titleTouched}
           onChange={onTitleChange}
-          className={`text-3xl font-bold mb-8 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
-          style={{ color: titleColor }}
+          className={`font-bold mb-8 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
+          style={{ color: titleColor, fontSize: titleSize }}
           pos={titlePos}
           onPosChange={onTitlePosChange}
           centerX
         />
         <DraggableEditableText
-          text={altText || 'Bizimkisi bir aşk hikayesi..'}
+          text={altText}
+          placeholder="Bizimkisi bir aşk hikayesi.."
+          touched={altTextTouched}
           onChange={onAltTextChange}
-          className={`text-sm mb-8 ${altFont ? `font-${altFont}` : 'font-sans'}`}
-          style={{ color: altColor }}
+          className={`${altFont ? `font-${altFont}` : 'font-sans'} mb-8`}
+          style={{ color: altColor, fontSize: altTextSize }}
           pos={altTextPos}
           onPosChange={onAltTextPosChange}
           centerX

--- a/src/components/Preview/WebPreview.js
+++ b/src/components/Preview/WebPreview.js
@@ -1,17 +1,23 @@
 import React from 'react';
 import DraggableEditableText from '../DraggableEditableText';
 
-const WebPreview = React.forwardRef(({
+const WebPreview = React.forwardRef(({ 
   slug,
   title,
   subtitle,
   altText,
   titleFont,
   titleColor,
+  titleSize,
   subtitleFont,
   subtitleColor,
+  subtitleSize,
   altFont,
   altColor,
+  altTextSize,
+  titleTouched,
+  subtitleTouched,
+  altTextTouched,
   onTitleChange,
   onSubtitleChange,
   onAltTextChange,
@@ -33,28 +39,34 @@ const WebPreview = React.forwardRef(({
     </div>
     <div className="flex-1 flex flex-col items-center justify-center text-center px-10 relative">
       <DraggableEditableText
-        text={subtitle || 'Sözümüze Hoşgeldiniz...'}
+        text={subtitle}
+        placeholder="Sözümüze Hoşgeldiniz..."
+        touched={subtitleTouched}
         onChange={onSubtitleChange}
-        className={`italic text-xl mb-4 ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
-        style={{ color: subtitleColor }}
+        className={`italic mb-4 ${subtitleFont ? `font-${subtitleFont}` : 'font-sans'}`}
+        style={{ color: subtitleColor, fontSize: subtitleSize }}
         pos={subtitlePos}
         onPosChange={onSubtitlePosChange}
         centerX
       />
       <DraggableEditableText
-        text={title || 'Burcu & Fatih'}
+        text={title}
+        placeholder="Burcu & Fatih"
+        touched={titleTouched}
         onChange={onTitleChange}
-        className={`text-5xl font-bold mb-3 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
-        style={{ color: titleColor }}
+        className={`font-bold mb-3 ${titleFont ? `font-${titleFont}` : 'font-sans'}`}
+        style={{ color: titleColor, fontSize: titleSize }}
         pos={titlePos}
         onPosChange={onTitlePosChange}
         centerX
       />
       <DraggableEditableText
-        text={altText || 'Bizimkisi bir aşk hikayesi..'}
+        text={altText}
+        placeholder="Bizimkisi bir aşk hikayesi.."
+        touched={altTextTouched}
         onChange={onAltTextChange}
-        className={`text-base mt-4 ${altFont ? `font-${altFont}` : 'font-sans'}`}
-        style={{ color: altColor }}
+        className={`${altFont ? `font-${altFont}` : 'font-sans'} mt-4`}
+        style={{ color: altColor, fontSize: altTextSize }}
         pos={altTextPos}
         onPosChange={onAltTextPosChange}
         centerX

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -29,11 +29,17 @@ const DashboardPage = () => {
   const [pages, setPages] = useState([]);
   const [titleFont, setTitleFont] = useState('romantic');
   const [titleColor, setTitleColor] = useState('#333333');
+  const [titleSize, setTitleSize] = useState(48);
+  const [titleTouched, setTitleTouched] = useState(false);
   const [subtitleFont, setSubtitleFont] = useState('sans');
   const [subtitleColor, setSubtitleColor] = useState('#555555');
+  const [subtitleSize, setSubtitleSize] = useState(24);
+  const [subtitleTouched, setSubtitleTouched] = useState(false);
   const [altText, setAltText] = useState('');
   const [altFont, setAltFont] = useState('sans');
   const [altColor, setAltColor] = useState('#888888');
+  const [altTextSize, setAltTextSize] = useState(16);
+  const [altTextTouched, setAltTextTouched] = useState(false);
   const [titlePos, setTitlePos] = useState({ x: 0, y: 0 });
   const [subtitlePos, setSubtitlePos] = useState({ x: 0, y: 0 });
   const [altTextPos, setAltTextPos] = useState({ x: 0, y: 0 });
@@ -200,11 +206,14 @@ const deleteCollection = async (collectionRef) => {
       subtitle,
       titleFont,
       titleColor,
+      titleSize,
       subtitleFont,
       subtitleColor,
+      subtitleSize,
       altText,
       altFont,
       altColor,
+      altTextSize,
       titlePos,
       subtitlePos,
       altTextPos,
@@ -216,24 +225,36 @@ const deleteCollection = async (collectionRef) => {
     await fetchUserPages();
     setSlug('');
     setTitle('');
+    setTitleTouched(false);
+    setTitleSize(48);
     setSubtitle('');
+    setSubtitleTouched(false);
+    setSubtitleSize(24);
     setTitlePos(defaultPositions.current.title);
     setSubtitlePos(defaultPositions.current.subtitle);
     setAltTextPos(defaultPositions.current.altText);
     setVideoLink('');
     setAltText('');
+    setAltTextTouched(false);
+    setAltTextSize(16);
   };
 
   const handleCancelEdit = () => {
     setEditingSlug(null);
     setSlug('');
     setTitle('');
+    setTitleTouched(false);
+    setTitleSize(48);
     setSubtitle('');
+    setSubtitleTouched(false);
+    setSubtitleSize(24);
     setTitlePos(defaultPositions.current.title);
     setSubtitlePos(defaultPositions.current.subtitle);
     setAltTextPos(defaultPositions.current.altText);
     setVideoLink('');
     setAltText('');
+    setAltTextTouched(false);
+    setAltTextSize(16);
   };
 
   const handleLogout = async () => {
@@ -306,13 +327,19 @@ const deleteCollection = async (collectionRef) => {
               altText={altText}
               titleFont={titleFont}
               titleColor={titleColor}
+              titleSize={titleSize}
               subtitleFont={subtitleFont}
               subtitleColor={subtitleColor}
+              subtitleSize={subtitleSize}
               altFont={altFont}
               altColor={altColor}
-              onTitleChange={setTitle}
-              onSubtitleChange={setSubtitle}
-              onAltTextChange={setAltText}
+              altTextSize={altTextSize}
+              titleTouched={titleTouched}
+              subtitleTouched={subtitleTouched}
+              altTextTouched={altTextTouched}
+              onTitleChange={(v) => { setTitle(v); setTitleTouched(true); }}
+              onSubtitleChange={(v) => { setSubtitle(v); setSubtitleTouched(true); }}
+              onAltTextChange={(v) => { setAltText(v); setAltTextTouched(true); }}
               titlePos={titlePos}
               subtitlePos={subtitlePos}
               altTextPos={altTextPos}
@@ -329,13 +356,19 @@ const deleteCollection = async (collectionRef) => {
               altText={altText}
               titleFont={titleFont}
               titleColor={titleColor}
+              titleSize={titleSize}
               subtitleFont={subtitleFont}
               subtitleColor={subtitleColor}
+              subtitleSize={subtitleSize}
               altFont={altFont}
               altColor={altColor}
-              onTitleChange={setTitle}
-              onSubtitleChange={setSubtitle}
-              onAltTextChange={setAltText}
+              altTextSize={altTextSize}
+              titleTouched={titleTouched}
+              subtitleTouched={subtitleTouched}
+              altTextTouched={altTextTouched}
+              onTitleChange={(v) => { setTitle(v); setTitleTouched(true); }}
+              onSubtitleChange={(v) => { setSubtitle(v); setSubtitleTouched(true); }}
+              onAltTextChange={(v) => { setAltText(v); setAltTextTouched(true); }}
               titlePos={titlePos}
               subtitlePos={subtitlePos}
               altTextPos={altTextPos}
@@ -380,7 +413,10 @@ const deleteCollection = async (collectionRef) => {
           <input
             type="text"
             value={title}
-            onChange={(e) => setTitle(e.target.value)}
+            onChange={(e) => {
+              setTitle(e.target.value);
+              setTitleTouched(true);
+            }}
             className="w-full border px-4 py-2 rounded"
             placeholder="Burcu & Fatih"
           />
@@ -416,13 +452,25 @@ const deleteCollection = async (collectionRef) => {
           <label className="block mb-1">🎨 Başlık Rengi</label>
           <input type="color" value={titleColor} onChange={(e) => setTitleColor(e.target.value)} className="w-16 h-10" />
         </div>
+        <div>
+          <label className="block mb-1">🔠 Başlık Boyutu</label>
+          <input
+            type="number"
+            value={titleSize}
+            onChange={(e) => setTitleSize(parseInt(e.target.value) || 0)}
+            className="w-full border px-4 py-2 rounded"
+          />
+        </div>
 
         <div>
           <label className="block mb-1">💬 Alt Mesaj</label>
           <input
             type="text"
             value={subtitle}
-            onChange={(e) => setSubtitle(e.target.value)}
+            onChange={(e) => {
+              setSubtitle(e.target.value);
+              setSubtitleTouched(true);
+            }}
             className="w-full border px-4 py-2 rounded"
             placeholder="Sözümüze hoşgeldiniz.."
           />
@@ -459,11 +507,23 @@ const deleteCollection = async (collectionRef) => {
           <input type="color" value={subtitleColor} onChange={(e) => setSubtitleColor(e.target.value)} className="w-16 h-10" />
         </div>
         <div>
+          <label className="block mb-1">🔠 Alt Mesaj Boyutu</label>
+          <input
+            type="number"
+            value={subtitleSize}
+            onChange={(e) => setSubtitleSize(parseInt(e.target.value) || 0)}
+            className="w-full border px-4 py-2 rounded"
+          />
+        </div>
+        <div>
           <label className="block mb-1">📍 Ek Açıklama (altText)</label>
           <input
             type="text"
             value={altText}
-            onChange={(e) => setAltText(e.target.value)}
+            onChange={(e) => {
+              setAltText(e.target.value);
+              setAltTextTouched(true);
+            }}
             className="w-full border px-4 py-2 rounded"
             placeholder="Örn: 14 Temmuz 2025, İstanbul"
           />
@@ -506,6 +566,15 @@ const deleteCollection = async (collectionRef) => {
             value={altColor}
             onChange={(e) => setAltColor(e.target.value)}
             className="w-16 h-10"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">🔠 Alt Yazı Boyutu</label>
+          <input
+            type="number"
+            value={altTextSize}
+            onChange={(e) => setAltTextSize(parseInt(e.target.value) || 0)}
+            className="w-full border px-4 py-2 rounded"
           />
         </div>
         <div>
@@ -560,12 +629,18 @@ const deleteCollection = async (collectionRef) => {
                     setAltFont(p.altFont || 'sans');
                     setTitleFont(p.titleFont || 'romantic');
                     setTitleColor(p.titleColor || '#333333');
+                    setTitleSize(p.titleSize || 48);
+                    setTitleTouched(true);
                     setTitle(p.title || '');
                     setSubtitle(p.subtitle || '');
+                    setSubtitleTouched(true);
                     setSubtitleColor(p.subtitleColor || '#555555');
                     setSubtitleFont(p.subtitleFont || 'sans');
+                    setSubtitleSize(p.subtitleSize || 24);
                     setVideoLink(p.videoLink || '');
                     setAltText(p.altText || '');
+                    setAltTextTouched(true);
+                    setAltTextSize(p.altTextSize || 16);
                     setTitlePos(p.titlePos || defaultPositions.current.title);
                     setSubtitlePos(p.subtitlePos || defaultPositions.current.subtitle);
                     setAltTextPos(p.altTextPos || defaultPositions.current.altText);
@@ -590,7 +665,10 @@ const deleteCollection = async (collectionRef) => {
                   placeholder="Çift İsmi"
                   className="w-full border px-4 py-2 rounded"
                   value={title}
-                  onChange={(e) => setTitle(e.target.value)}
+                  onChange={(e) => {
+                    setTitle(e.target.value);
+                    setTitleTouched(true);
+                  }}
                 />
                 <div>
                   <label className="block mb-1">🖋️ Başlık Fontu</label>
@@ -604,12 +682,24 @@ const deleteCollection = async (collectionRef) => {
                   <label className="block mb-1">🎨 Başlık Rengi</label>
                   <input type="color" value={titleColor} onChange={(e) => setTitleColor(e.target.value)} className="w-16 h-10" />
                 </div>
+                <div>
+                  <label className="block mb-1">🔠 Başlık Boyutu</label>
+                  <input
+                    type="number"
+                    value={titleSize}
+                    onChange={(e) => setTitleSize(parseInt(e.target.value) || 0)}
+                    className="w-full border px-4 py-2 rounded"
+                  />
+                </div>
                 <input
                   type="text"
                   placeholder="Alt Mesaj"
                   className="w-full border px-4 py-2 rounded"
                   value={subtitle}
-                  onChange={(e) => setSubtitle(e.target.value)}
+                  onChange={(e) => {
+                    setSubtitle(e.target.value);
+                    setSubtitleTouched(true);
+                  }}
                 />
                 <div>
                   <label className="block mb-1">🖋️ Alt Yazı Fontu</label>
@@ -623,13 +713,25 @@ const deleteCollection = async (collectionRef) => {
                   <label className="block mb-1">🎨 Alt Yazı Rengi</label>
                   <input type="color" value={subtitleColor} onChange={(e) => setSubtitleColor(e.target.value)} className="w-16 h-10" />
                 </div>
+                <div>
+                  <label className="block mb-1">🔠 Alt Mesaj Boyutu</label>
+                  <input
+                    type="number"
+                    value={subtitleSize}
+                    onChange={(e) => setSubtitleSize(parseInt(e.target.value) || 0)}
+                    className="w-full border px-4 py-2 rounded"
+                  />
+                </div>
 
                 <div>
                   <label className="block mb-1">📍 Ek Açıklama (altText)</label>
                   <input
                     type="text"
                     value={altText}
-                    onChange={(e) => setAltText(e.target.value)}
+                    onChange={(e) => {
+                      setAltText(e.target.value);
+                      setAltTextTouched(true);
+                    }}
                     className="w-full border px-4 py-2 rounded"
                     placeholder="Örn: 14 Temmuz 2025, İstanbul"
                   />
@@ -658,6 +760,15 @@ const deleteCollection = async (collectionRef) => {
                   />
                 </div>
                 <div>
+                  <label className="block mb-1">🔠 Alt Yazı Boyutu</label>
+                  <input
+                    type="number"
+                    value={altTextSize}
+                    onChange={(e) => setAltTextSize(parseInt(e.target.value) || 0)}
+                    className="w-full border px-4 py-2 rounded"
+                  />
+                </div>
+                <div>
                   <label className="block mb-1">🎥 Video Linki</label>
                 <input
                   type="text"
@@ -676,11 +787,14 @@ const deleteCollection = async (collectionRef) => {
                       subtitle,
                       titleFont,
                       titleColor,
+                      titleSize,
                       subtitleFont,
                       subtitleColor,
+                      subtitleSize,
                       altText,
                       altFont,
                       altColor,
+                      altTextSize,
                       titlePos,
                       subtitlePos,
                       altTextPos,

--- a/src/pages/HeroPage.js
+++ b/src/pages/HeroPage.js
@@ -37,10 +37,16 @@ const HeroPage = () => {
   // Font ve renk state'leri
   const [titleFont, setTitleFont] = useState('romantic');
   const [titleColor, setTitleColor] = useState('#333333');
+  const [titleSize, setTitleSize] = useState(48);
+  const [titleTouched, setTitleTouched] = useState(false);
   const [subtitleFont, setSubtitleFont] = useState('modern');
   const [subtitleColor, setSubtitleColor] = useState('#555555');
+  const [subtitleSize, setSubtitleSize] = useState(24);
+  const [subtitleTouched, setSubtitleTouched] = useState(false);
   const [altFont, setAltFont] = useState('modern');
   const [altColor, setAltColor] = useState('#888888');
+  const [altTextSize, setAltTextSize] = useState(16);
+  const [altTextTouched, setAltTextTouched] = useState(false);
   const previewRef = useRef(null);
   const DEFAULT_RATIOS = {
     title: 0.43,
@@ -213,10 +219,13 @@ const HeroPage = () => {
         createdAt: new Date(),
         titleFont,
         titleColor,
+        titleSize,
         subtitleFont,
         subtitleColor,
+        subtitleSize,
         altFont,
         altColor,
+        altTextSize,
         titlePos,
         subtitlePos,
         altTextPos
@@ -247,8 +256,14 @@ const HeroPage = () => {
     setPassword('');
     setSlug('');
     setTitle('');
+    setTitleTouched(false);
+    setTitleSize(48);
     setSubtitle('');
+    setSubtitleTouched(false);
+    setSubtitleSize(24);
     setAltText('');
+    setAltTextTouched(false);
+    setAltTextSize(16);
     setVideoLink('');
     setSlugExists(false);
     setSlugMessage('');
@@ -377,13 +392,19 @@ const HeroPage = () => {
               altText={altText}
               titleFont={titleFont}
               titleColor={titleColor}
+              titleSize={titleSize}
               subtitleFont={subtitleFont}
               subtitleColor={subtitleColor}
+              subtitleSize={subtitleSize}
               altFont={altFont}
               altColor={altColor}
-              onTitleChange={setTitle}
-              onSubtitleChange={setSubtitle}
-              onAltTextChange={setAltText}
+              altTextSize={altTextSize}
+              titleTouched={titleTouched}
+              subtitleTouched={subtitleTouched}
+              altTextTouched={altTextTouched}
+              onTitleChange={(v) => { setTitle(v); setTitleTouched(true); }}
+              onSubtitleChange={(v) => { setSubtitle(v); setSubtitleTouched(true); }}
+              onAltTextChange={(v) => { setAltText(v); setAltTextTouched(true); }}
               titlePos={titlePos}
               subtitlePos={subtitlePos}
               altTextPos={altTextPos}
@@ -400,13 +421,19 @@ const HeroPage = () => {
               altText={altText}
               titleFont={titleFont}
               titleColor={titleColor}
+              titleSize={titleSize}
               subtitleFont={subtitleFont}
               subtitleColor={subtitleColor}
+              subtitleSize={subtitleSize}
               altFont={altFont}
               altColor={altColor}
-              onTitleChange={setTitle}
-              onSubtitleChange={setSubtitle}
-              onAltTextChange={setAltText}
+              altTextSize={altTextSize}
+              titleTouched={titleTouched}
+              subtitleTouched={subtitleTouched}
+              altTextTouched={altTextTouched}
+              onTitleChange={(v) => { setTitle(v); setTitleTouched(true); }}
+              onSubtitleChange={(v) => { setSubtitle(v); setSubtitleTouched(true); }}
+              onAltTextChange={(v) => { setAltText(v); setAltTextTouched(true); }}
               titlePos={titlePos}
               subtitlePos={subtitlePos}
               altTextPos={altTextPos}
@@ -497,7 +524,10 @@ const HeroPage = () => {
                 <input
                   type="text"
                   value={title}
-                  onChange={(e) => setTitle(e.target.value)}
+                  onChange={(e) => {
+                    setTitle(e.target.value);
+                    setTitleTouched(true);
+                  }}
                   placeholder="Burcu & Fatih"
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent"
                 />
@@ -519,6 +549,15 @@ const HeroPage = () => {
                     className="w-full h-10 border border-gray-300 rounded-lg"
                   />
                 </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Başlık Boyutu</label>
+                  <input
+                    type="number"
+                    value={titleSize}
+                    onChange={(e) => setTitleSize(parseInt(e.target.value) || 0)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                  />
+                </div>
               </div>
 
               <div>
@@ -526,7 +565,10 @@ const HeroPage = () => {
                 <input
                   type="text"
                   value={subtitle}
-                  onChange={(e) => setSubtitle(e.target.value)}
+                  onChange={(e) => {
+                    setSubtitle(e.target.value);
+                    setSubtitleTouched(true);
+                  }}
                   placeholder="Sözümüze Hoşgeldiniz..."
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent"
                 />
@@ -548,6 +590,15 @@ const HeroPage = () => {
                     className="w-full h-10 border border-gray-300 rounded-lg"
                   />
                 </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Üst Yazı Boyutu</label>
+                  <input
+                    type="number"
+                    value={subtitleSize}
+                    onChange={(e) => setSubtitleSize(parseInt(e.target.value) || 0)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                  />
+                </div>
               </div>
 
               <div>
@@ -555,7 +606,10 @@ const HeroPage = () => {
                 <input
                   type="text"
                   value={altText}
-                  onChange={(e) => setAltText(e.target.value)}
+                  onChange={(e) => {
+                    setAltText(e.target.value);
+                    setAltTextTouched(true);
+                  }}
                   placeholder="Bizimkisi bir aşk hikayesi.."
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent"
                 />
@@ -575,6 +629,15 @@ const HeroPage = () => {
                     value={altColor}
                     onChange={(e) => setAltColor(e.target.value)}
                     className="w-full h-10 border border-gray-300 rounded-lg"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Alt Yazı Boyutu</label>
+                  <input
+                    type="number"
+                    value={altTextSize}
+                    onChange={(e) => setAltTextSize(parseInt(e.target.value) || 0)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg"
                   />
                 </div>
               </div>

--- a/src/pages/SlugPage.js
+++ b/src/pages/SlugPage.js
@@ -89,9 +89,10 @@ useEffect(() => {
         className="min-h-screen flex flex-col justify-center items-center text-center relative"
       >
         <p
-          className={`italic text-xl font-${page.subtitleFont} mb-4 absolute`}
+          className={`italic font-${page.subtitleFont} mb-4 absolute`}
           style={{
             color: page.subtitleColor,
+            fontSize: page.subtitleSize || 24,
             left: scaledSubtitlePos?.x,
             top: scaledSubtitlePos?.y,
             transform: 'translateX(-50%)',
@@ -100,9 +101,10 @@ useEffect(() => {
           {page.subtitle}
         </p>
         <h1
-          className={`text-5xl font-${page.titleFont} mb-3 absolute`}
+          className={`font-${page.titleFont} mb-3 absolute`}
           style={{
             color: page.titleColor,
+            fontSize: page.titleSize || 48,
             left: scaledTitlePos?.x,
             top: scaledTitlePos?.y,
             transform: 'translateX(-50%)',
@@ -111,9 +113,10 @@ useEffect(() => {
           {page.title}
         </h1>
         <p
-          className={`text-base font-${page.altFont} mt-4 absolute`}
+          className={`font-${page.altFont} mt-4 absolute`}
           style={{
             color: page.altColor,
+            fontSize: page.altTextSize || 16,
             left: scaledAltTextPos?.x,
             top: scaledAltTextPos?.y,
             transform: 'translateX(-50%)',


### PR DESCRIPTION
## Summary
- allow placeholders in `DraggableEditableText`
- support font size and touched state in phone/web previews
- store new size fields in Firestore
- expose controls for text sizes on dashboard and initial page
- render saved sizes on final pages

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688bec31b0cc832d9b1c3d31b90633f7